### PR TITLE
Improve client

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -36,6 +36,7 @@ type Client struct {
 	userAgent  string
 	httpClient *http.Client
 
+	Headers  map[string]string
 	Rulesets *RulesetService
 }
 
@@ -43,6 +44,8 @@ type Client struct {
 func New(baseURL string, opts ...Option) (*Client, error) {
 	var c Client
 	var err error
+
+	c.Headers = make(map[string]string)
 
 	c.baseURL, err = url.Parse(baseURL)
 	if err != nil {
@@ -97,6 +100,10 @@ func (c *Client) newRequest(method, path string, body interface{}) (*http.Reques
 	req, err := http.NewRequest(method, u.String(), r)
 	if err != nil {
 		return nil, err
+	}
+
+	for k, v := range c.Headers {
+		req.Header.Set(k, v)
 	}
 
 	if body != nil {
@@ -220,6 +227,14 @@ func HTTPClient(httpClient *http.Client) Option {
 func UserAgent(userAgent string) Option {
 	return func(c *Client) error {
 		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// Header adds a key value pair to the headers sent on each request.
+func Header(k, v string) Option {
+	return func(c *Client) error {
+		c.Headers[k] = v
 		return nil
 	}
 }

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/heetch/regula/api"
@@ -21,7 +22,7 @@ import (
 const (
 	userAgent  = "Regula/" + version.Version + " Go"
 	watchDelay = 1 * time.Second
-	retryDelay = 1 * time.Second
+	retryDelay = 250 * time.Millisecond
 	retries    = 3
 )
 
@@ -46,6 +47,10 @@ func New(baseURL string, opts ...Option) (*Client, error) {
 	c.baseURL, err = url.Parse(baseURL)
 	if err != nil {
 		return nil, err
+	}
+
+	if !strings.HasSuffix(c.baseURL.Path, "/") {
+		c.baseURL.Path += "/"
 	}
 
 	for _, opt := range opts {

--- a/api/client/rulesets.go
+++ b/api/client/rulesets.go
@@ -19,9 +19,18 @@ type RulesetService struct {
 	client *Client
 }
 
+func (s *RulesetService) joinPath(path string) string {
+	path = "./" + ppath.Join("rulesets/", path)
+	if path == "./rulesets" {
+		return path + "/"
+	}
+
+	return path
+}
+
 // List fetches all the rulesets starting with the given prefix.
 func (s *RulesetService) List(ctx context.Context, prefix string, opt *ListOptions) (*api.Rulesets, error) {
-	req, err := s.client.newRequest("GET", ppath.Join("/rulesets/", prefix), nil)
+	req, err := s.client.newRequest("GET", s.joinPath(prefix), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +65,7 @@ func (s *RulesetService) Eval(ctx context.Context, path string, params rule.Para
 // EvalVersion evaluates the given ruleset version with the given params.
 // It implements the regula.Evaluator interface and thus can be passed to the regula.Engine.
 func (s *RulesetService) EvalVersion(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error) {
-	req, err := s.client.newRequest("GET", ppath.Join("/rulesets/", path), nil)
+	req, err := s.client.newRequest("GET", s.joinPath(path), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +100,7 @@ func (s *RulesetService) EvalVersion(ctx context.Context, path, version string, 
 
 // Put creates a ruleset version on the given path.
 func (s *RulesetService) Put(ctx context.Context, path string, rs *regula.Ruleset) (*api.Ruleset, error) {
-	req, err := s.client.newRequest("PUT", ppath.Join("/rulesets/", path), rs)
+	req, err := s.client.newRequest("PUT", s.joinPath(path), rs)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +135,7 @@ func (s *RulesetService) Watch(ctx context.Context, prefix string, revision stri
 			default:
 			}
 
-			req, err := s.client.newRequest("GET", ppath.Join("/rulesets/", prefix), nil)
+			req, err := s.client.newRequest("GET", s.joinPath(prefix), nil)
 			if err != nil {
 				ch <- WatchResponse{Err: errors.Wrap(err, "failed to create watch request")}
 				return

--- a/api/client/rulesets_test.go
+++ b/api/client/rulesets_test.go
@@ -216,6 +216,8 @@ func TestRulesetService(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					assert.NotEmpty(t, r.Header.Get("User-Agent"))
 					assert.Equal(t, "application/json", r.Header.Get("Accept"))
+					assert.Equal(t, "hv1", r.Header.Get("hk1"))
+					assert.Equal(t, "hv2", r.Header.Get("hk2"))
 					assert.Contains(t, r.URL.Query(), "list")
 					assert.Equal(t, "some-token", r.URL.Query().Get("continue"))
 					assert.Equal(t, "10", r.URL.Query().Get("limit"))
@@ -224,9 +226,10 @@ func TestRulesetService(t *testing.T) {
 				}))
 				defer ts.Close()
 
-				cli, err := client.New(ts.URL + "/subpath")
+				cli, err := client.New(ts.URL+"/subpath", client.Header("hk1", "hv1"))
 				require.NoError(t, err)
 				cli.Logger = zerolog.New(ioutil.Discard)
+				cli.Headers["hk2"] = "hv2"
 
 				rs, err := cli.Rulesets.List(context.Background(), tc.path, &client.ListOptions{
 					Limit:    10,


### PR DESCRIPTION
This PR improves the http client in several ways:

- Prevent unnecessary server redirection on root "/rulesets" by making sure the trailing slash is present
- Allow to use an URL with a parent path
- Support passing custom headers to all the requests
- Lower the default waiting time between failed requests