### PR TITLE
Return a 200 status code when watch request times out

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -28,13 +28,13 @@ const (
 
 // A Client manages communication with the Rules Engine API using HTTP.
 type Client struct {
-	Logger     zerolog.Logger
-	WatchDelay time.Duration // Time between failed watch requests. Defaults to 1s.
-	RetryDelay time.Duration // Time between failed requests retries. Defaults to 1s.
-	Retries    int           // Number of retries on retriable errors.
-	baseURL    *url.URL
-	userAgent  string
-	httpClient *http.Client
+	Logger          zerolog.Logger
+	WatchRetryDelay time.Duration // Time between failed watch requests. Defaults to 1s.
+	RetryDelay      time.Duration // Time between failed requests retries. Defaults to 1s.
+	Retries         int           // Number of retries on retriable errors.
+	baseURL         *url.URL
+	userAgent       string
+	httpClient      *http.Client
 
 	Headers  map[string]string
 	Rulesets *RulesetService
@@ -69,7 +69,7 @@ func New(baseURL string, opts ...Option) (*Client, error) {
 	}
 
 	c.Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
-	c.WatchDelay = watchDelay
+	c.WatchRetryDelay = watchDelay
 	c.RetryDelay = retryDelay
 	c.Retries = retries
 

--- a/api/client/rulesets.go
+++ b/api/client/rulesets.go
@@ -156,8 +156,6 @@ func (s *RulesetService) Watch(ctx context.Context, prefix string, revision stri
 					case http.StatusNotFound:
 						ch <- WatchResponse{Err: err}
 						return
-					case http.StatusRequestTimeout:
-						s.client.Logger.Debug().Err(err).Msg("watch request timed out")
 					case http.StatusInternalServerError:
 						s.client.Logger.Debug().Err(err).Msg("watch request failed: internal server error")
 					default:
@@ -176,6 +174,12 @@ func (s *RulesetService) Watch(ctx context.Context, prefix string, revision stri
 				}
 
 				// avoid too many requests on errors.
+				time.Sleep(s.client.WatchDelay)
+				continue
+			}
+
+			if events.Timeout {
+				s.client.Logger.Debug().Msg("watch request timed out")
 				time.Sleep(s.client.WatchDelay)
 				continue
 			}

--- a/api/client/rulesets.go
+++ b/api/client/rulesets.go
@@ -174,13 +174,13 @@ func (s *RulesetService) Watch(ctx context.Context, prefix string, revision stri
 				}
 
 				// avoid too many requests on errors.
-				time.Sleep(s.client.WatchDelay)
+				time.Sleep(s.client.WatchRetryDelay)
 				continue
 			}
 
 			if events.Timeout {
 				s.client.Logger.Debug().Msg("watch request timed out")
-				time.Sleep(s.client.WatchDelay)
+				time.Sleep(s.client.WatchRetryDelay)
 				continue
 			}
 

--- a/api/client/rulesets_test.go
+++ b/api/client/rulesets_test.go
@@ -349,7 +349,7 @@ func TestRulesetService(t *testing.T) {
 		cli, err := client.New(ts.URL)
 		require.NoError(t, err)
 		cli.Logger = zerolog.New(ioutil.Discard)
-		cli.WatchDelay = 1 * time.Millisecond
+		cli.WatchRetryDelay = 1 * time.Millisecond
 
 		ch := cli.Rulesets.Watch(ctx, "a", "")
 		evs := <-ch
@@ -400,7 +400,7 @@ func TestRulesetService(t *testing.T) {
 			cli, err := client.New(ts.URL)
 			require.NoError(t, err)
 			cli.Logger = zerolog.New(ioutil.Discard)
-			cli.WatchDelay = 1 * time.Millisecond
+			cli.WatchRetryDelay = 1 * time.Millisecond
 
 			ch := cli.Rulesets.Watch(ctx, "a", "")
 			evs := <-ch

--- a/api/server/api_test.go
+++ b/api/server/api_test.go
@@ -248,9 +248,11 @@ func TestAPI(t *testing.T) {
 				var res store.RulesetEvents
 				err := json.NewDecoder(w.Body).Decode(&res)
 				require.NoError(t, err)
-				require.Equal(t, len(l.Events), len(res.Events))
-				for i := range l.Events {
-					require.Equal(t, l.Events[i], res.Events[i])
+				if es != nil {
+					require.Equal(t, len(es.Events), len(res.Events))
+					for i := range l.Events {
+						require.Equal(t, l.Events[i], res.Events[i])
+					}
 				}
 			}
 		}
@@ -289,7 +291,7 @@ func TestAPI(t *testing.T) {
 		})
 
 		t.Run("Timeout", func(t *testing.T) {
-			call(t, "/rulesets/?watch", http.StatusRequestTimeout, nil, context.DeadlineExceeded)
+			call(t, "/rulesets/?watch", http.StatusOK, nil, context.DeadlineExceeded)
 		})
 	})
 

--- a/api/types.go
+++ b/api/types.go
@@ -57,6 +57,7 @@ type Event struct {
 
 // Events holds a list of events occured on a group of rulesets.
 type Events struct {
-	Events   []Event `json:"events"`
-	Revision string  `json:"revision"`
+	Events   []Event `json:"events,omitempty"`
+	Revision string  `json:"revision,omitempty"`
+	Timeout  bool    `json:"timeout,omitempty"`
 }


### PR DESCRIPTION
This PR returns a 200 instead of a 408 when a watch request times out