### PR TITLE
Set User-Agent header in client via Header function / Option and not via a special function

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// When no User-Agent header is provided, newRequest causes the default value to be used.
+func TestNewRequestDefaultsUserAgentWhenNoneIsSpecified(t *testing.T) {
+	client, err := New("http://www.example.com")
+	require.NoError(t, err)
+	req, err := client.newRequest("my-method", "/api/test", nil)
+	require.NoError(t, err)
+	ua := req.Header.Get("User-Agent")
+	require.Equal(t, userAgent, ua)
+}
+
+// When we provide a User-Agent header, newRequest uses this value instead of the default.
+func TestNewRequestPrefersSpecifiedUserAgentHeaderToDefault(t *testing.T) {
+	expUA := "Regula/Test Go"
+	hO := Header("User-Agent", expUA)
+	client, err := New("http://www.example.com", hO)
+	require.NoError(t, err)
+	req, err := client.newRequest("my-method", "/api/test", nil)
+	require.NoError(t, err)
+	ua := req.Header.Get("User-Agent")
+	require.Equal(t, expUA, ua)
+}


### PR DESCRIPTION
Fixes: #5 

This branch removes the `UserAgent` function from the regula api client, and instead supports setting the `User-Agent` header only via the `Header` function, whose `Option` return value can be passed to `New`.

Along the way, I added a `client_test.go` file that tests for the correct behavior (defaulting the user agent if none is specified, overriding that default if the header is set).  
