### PR TITLE
Scanner and contiguous sequence readers for symbolic expression lexer 

### DIFF
--- a/rule/sexpr/lexer.go
+++ b/rule/sexpr/lexer.go
@@ -139,5 +139,5 @@ type ScanError struct {
 
 //
 func (se *ScanError) Error() string {
-	return se.msg
+	return fmt.Sprintf("Error:%d,%d: %s", se.Line, se.CharInLine, se.msg)
 }

--- a/rule/sexpr/lexer.go
+++ b/rule/sexpr/lexer.go
@@ -2,6 +2,7 @@ package sexpr
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"unicode"
 )

--- a/rule/sexpr/lexer.go
+++ b/rule/sexpr/lexer.go
@@ -400,7 +400,7 @@ func (s *Scanner) scanSymbol() (Token, string, error) {
 		if err != nil {
 			se := err.(*ScanError)
 			if se.EOF {
-				// EOF is a valid terminator for a Comment
+				// EOF is a valid terminator for a Symbol
 				break
 			}
 			return SYMBOL, b.String(), err

--- a/rule/sexpr/lexer.go
+++ b/rule/sexpr/lexer.go
@@ -95,11 +95,12 @@ func (s *Scanner) Scan() (Token, string, error) {
 	switch {
 	case isLParen(rn):
 		return LPAREN, "(", nil
+	case isRParen(rn):
+		return RPAREN, ")", nil
 	}
 	return EOF, string(rn), s.newScanError("Illegal character scanned")
 }
 
-//
 func (s *Scanner) readRune() (rune, error) {
 	rn, size, err := s.r.ReadRune()
 	s.byteCount += size

--- a/rule/sexpr/lexer.go
+++ b/rule/sexpr/lexer.go
@@ -343,7 +343,7 @@ func (s *Scanner) scanBool() (Token, string, error) {
 		if err != nil {
 			se := err.(*ScanError)
 			if se.EOF {
-				// EOF is a valid terminator for a number
+				// EOF is a valid terminator for a boolean
 				break
 			}
 			return BOOL, b.String(), err

--- a/rule/sexpr/lexer.go
+++ b/rule/sexpr/lexer.go
@@ -84,7 +84,10 @@ type Scanner struct {
 // might scan lexical tokens for the rule symbolic expression language
 // from it.
 func NewScanner(r io.Reader) *Scanner {
-	return &Scanner{r: bufio.NewReader(r)}
+	return &Scanner{
+		r:         bufio.NewReader(r),
+		lineCount: 1,
+	}
 }
 
 // Scan returns the next lexical token found in the Scanner's io.Reader.
@@ -124,7 +127,7 @@ func (s *Scanner) newScanError(message string) *ScanError {
 	return &ScanError{
 		Byte:       s.byteCount,
 		Char:       s.charCount,
-		Line:       s.lineCount + 1,
+		Line:       s.lineCount,
 		CharInLine: s.lineCharCount,
 		msg:        message,
 	}

--- a/rule/sexpr/lexer.go
+++ b/rule/sexpr/lexer.go
@@ -99,7 +99,11 @@ func NewScanner(r io.Reader) *Scanner {
 func (s *Scanner) Scan() (Token, string, error) {
 	rn, err := s.readRune()
 	if err != nil {
-		return EOF, "", s.newScanError(err.Error())
+		se := err.(*ScanError)
+		if se.EOF {
+			return EOF, "", nil
+		}
+		return EOF, "", err
 	}
 	switch {
 	case isLParen(rn):

--- a/rule/sexpr/lexer.go
+++ b/rule/sexpr/lexer.go
@@ -1,6 +1,10 @@
 package sexpr
 
-import "unicode"
+import (
+	"bufio"
+	"io"
+	"unicode"
+)
 
 type Token int
 
@@ -63,4 +67,17 @@ func isComment(r rune) bool {
 // the rune.
 func isSymbol(r rune) bool {
 	return !(isWhitespace(r) || isLParen(r) || isRParen(r) || isString(r) || isNumber(r) || isBool(r) || isComment(r))
+}
+
+// Scanner is a lexical scanner for extracting the lexical tokens from
+// a string of characters in our rule symbolic expression language.
+type Scanner struct {
+	r *bufio.Reader
+}
+
+// NewScanner wraps a Scanner around the provided io.Reader so that we
+// might scan lexical tokens for the rule symbolic expression language
+// from it.
+func NewScanner(r io.Reader) *Scanner {
+	return &Scanner{r: bufio.NewReader(r)}
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -161,17 +161,17 @@ func TestNewScanner(t *testing.T) {
 }
 
 func assertScanned(t *testing.T, input string, token Token, byteCount, charCount, lineCount, lineCharCount int) {
-	t.Run(fmt.Sprintf("Scan %s", input), func(t *testing.T) {
+	t.Run(fmt.Sprintf("Scan %s 0x%x", input, input), func(t *testing.T) {
 		b := bytes.NewBufferString(input)
 		s := NewScanner(b)
 		tok, lit, err := s.Scan()
 		require.NoError(t, err)
 		require.Equal(t, token, tok)
 		require.Equal(t, input, lit)
-		require.Equal(t, byteCount, s.byteCount)
-		require.Equal(t, charCount, s.charCount)
-		require.Equal(t, lineCount, s.lineCount)
-		require.Equal(t, lineCharCount, s.lineCharCount)
+		require.Equalf(t, byteCount, s.byteCount, "byteCount")
+		require.Equalf(t, charCount, s.charCount, "charCount")
+		require.Equalf(t, lineCount, s.lineCount, "lineCount")
+		require.Equalf(t, lineCharCount, s.lineCharCount, "lineCharCount")
 	})
 }
 
@@ -179,4 +179,9 @@ func TestScannerScan(t *testing.T) {
 	assertScanned(t, "(", LPAREN, 1, 1, 1, 1)
 	assertScanned(t, ")", RPAREN, 1, 1, 1, 1)
 	assertScanned(t, " ", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "\t", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "\r", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "\n", WHITESPACE, 1, 1, 2, 0)
+	assertScanned(t, "\v", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "\f", WHITESPACE, 1, 1, 1, 1)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -218,6 +218,8 @@ func TestScannerScan(t *testing.T) {
 	assertScanned(t, "1", "1", NUMBER, 1, 1, 1, 1)
 	// - Single digit integer, terminated by non-number character
 	assertScanned(t, "1)", "1", NUMBER, 1, 1, 1, 1)
-	// - Multi digit integer, EOF terminated
+	// - Multi-digit integer, EOF terminated
 	assertScanned(t, "998989", "998989", NUMBER, 6, 6, 1, 6)
+	// - Negative multi-digit integer, EOF terminated
+	assertScanned(t, "-100", "-100", NUMBER, 4, 4, 1, 4)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -213,4 +213,9 @@ func TestScannerScan(t *testing.T) {
 	assertScanned(t, `"foo\""`, `foo"`, STRING, 7, 7, 1, 7)
 	// - sad case with escaped terminator
 	assertScanFailed(t, `"foo\"`, "Error:1,6: unterminated string constant")
+	// Test number
+	// - Single digit integer, EOF terminated
+	assertScanned(t, "1", "1", NUMBER, 1, 1, 1, 1)
+	// - Single digit integer, terminated by non-number character
+	assertScanned(t, "1)", "1", NUMBER, 1, 1, 1, 1)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -248,8 +248,6 @@ func TestScannerScanNumber(t *testing.T) {
 	assertScanned(t, "- 1 2", "-", SYMBOL, 1, 1, 1, 1)
 	// - sad case: a minus mid-number
 	assertScanFailed(t, "1-2", "Error:1,2: invalid number format (minus can only appear at the beginning of a number)")
-	// - sad case: a minus followed by EOF
-	assertScanFailed(t, "-", "Error:1,1: EOF")
 }
 
 func TestScannerScanBool(t *testing.T) {

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -2,6 +2,7 @@ package sexpr
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
 
@@ -159,13 +160,17 @@ func TestNewScanner(t *testing.T) {
 	require.Equal(t, expected, content)
 }
 
-func TestScannerScan(t *testing.T) {
-	expected := "("
-	b := bytes.NewBufferString(expected)
-	s := NewScanner(b)
-	tok, lit, err := s.Scan()
-	require.NoError(t, err)
-	require.Equal(t, tok, LPAREN)
-	require.Equal(t, lit, "(")
+func assertScanned(t *testing.T, input string, token Token) {
+	t.Run(fmt.Sprintf("Scan %s", input), func(t *testing.T) {
+		b := bytes.NewBufferString(input)
+		s := NewScanner(b)
+		tok, lit, err := s.Scan()
+		require.NoError(t, err)
+		require.Equal(t, token, tok)
+		require.Equal(t, input, lit)
+	})
+}
 
+func TestScannerScan(t *testing.T) {
+	assertScanned(t, "(", LPAREN)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -173,4 +173,5 @@ func assertScanned(t *testing.T, input string, token Token) {
 
 func TestScannerScan(t *testing.T) {
 	assertScanned(t, "(", LPAREN)
+	assertScanned(t, ")", RPAREN)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -185,11 +185,14 @@ func assertScanFailed(t *testing.T, input, message string) {
 
 }
 
-func TestScannerScan(t *testing.T) {
+func TestScannerScanParenthesis(t *testing.T) {
 	// Test L Parenthesis
 	assertScanned(t, "(", "(", LPAREN, 1, 1, 1, 1)
 	// Test R Parenthesis
 	assertScanned(t, ")", ")", RPAREN, 1, 1, 1, 1)
+}
+
+func TestScannerScanWhiteSpace(t *testing.T) {
 	// Test white-space
 	assertScanned(t, " ", " ", WHITESPACE, 1, 1, 1, 1)
 	assertScanned(t, "\t", "\t", WHITESPACE, 1, 1, 1, 1)
@@ -202,6 +205,9 @@ func TestScannerScan(t *testing.T) {
 	assertScanned(t, "  ", "  ", WHITESPACE, 2, 2, 1, 2)
 	// - terminated by non white-space character.
 	assertScanned(t, "  (", "  ", WHITESPACE, 2, 2, 1, 2)
+}
+
+func TestScannerScanString(t *testing.T) {
 	// Test string:
 	// - the empty string
 	assertScanned(t, `""`, "", STRING, 2, 2, 1, 2)
@@ -213,6 +219,9 @@ func TestScannerScan(t *testing.T) {
 	assertScanned(t, `"foo\""`, `foo"`, STRING, 7, 7, 1, 7)
 	// - sad case with escaped terminator
 	assertScanFailed(t, `"foo\"`, "Error:1,6: unterminated string constant")
+}
+
+func TestScannerScanNumber(t *testing.T) {
 	// Test number
 	// - Single digit integer, EOF terminated
 	assertScanned(t, "1", "1", NUMBER, 1, 1, 1, 1)
@@ -230,5 +239,16 @@ func TestScannerScan(t *testing.T) {
 	assertScanned(t, "- 1 2", "-", SYMBOL, 1, 1, 1, 1)
 	// - sad case: a minus mid-number
 	assertScanFailed(t, "1-2", "Error:1,2: invalid number format (minus can only appear at the beginning of a number)")
+	// - sad case: a minus followed by EOF
 	assertScanFailed(t, "-", "Error:1,1: EOF")
+}
+
+func TestScannerScanBool(t *testing.T) {
+	assertScanned(t, "#true", "true", BOOL, 5, 5, 1, 5)
+	assertScanned(t, "#false", "false", BOOL, 6, 6, 1, 6)
+	assertScanFailed(t, "#tru ", "Error:1,4: invalid boolean: tru")
+	assertScanFailed(t, "#fa)", "Error:1,3: invalid boolean: fa")
+	assertScanFailed(t, "#1", "Error:1,1: invalid boolean")
+	assertScanFailed(t, "##", "Error:1,1: invalid boolean")
+	assertScanFailed(t, "#", "Error:1,1: invalid boolean")
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -272,3 +272,22 @@ func TestScannerScanComment(t *testing.T) {
 	// Comment containing control characters
 	assertScanned(t, `;()"-#1`, `()"-#1`, COMMENT, 7, 7, 1, 7)
 }
+
+func TestScannerScanSymbol(t *testing.T) {
+	// Simple, single character identifier
+	assertScanned(t, "a", "a", SYMBOL, 1, 1, 1, 1)
+	// Fully formed symbol
+	assertScanned(t, "abba-sucks-123_ok!", "abba-sucks-123_ok!", SYMBOL, 18, 18, 1, 18)
+	// Unicode in symbols
+	assertScanned(t, "mötlěy_crü_sucks_more", "mötlěy_crü_sucks_more", SYMBOL, 24, 21, 1, 21)
+	// terminated by comment
+	assertScanned(t, "bon;jovi is worse", "bon", SYMBOL, 3, 3, 1, 3)
+	// terminated by whitespace
+	assertScanned(t, "van halen is the worst", "van", SYMBOL, 3, 3, 1, 3)
+	// terminated by control character
+	assertScanned(t, "NoWayMichaelBolton)IsTheNadir", "NoWayMichaelBolton", SYMBOL, 18, 18, 1, 18)
+	// symbol starting with a non-alpha character
+	assertScanned(t, "+", "+", SYMBOL, 1, 1, 1, 1)
+	// actually handled by the number scan, but we'll check '-' all the same:
+	assertScanned(t, "-", "-", SYMBOL, 1, 1, 1, 1)
+}

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -160,14 +160,14 @@ func TestNewScanner(t *testing.T) {
 	require.Equal(t, expected, content)
 }
 
-func assertScanned(t *testing.T, input string, token Token, byteCount, charCount, lineCount, lineCharCount int) {
+func assertScanned(t *testing.T, input, output string, token Token, byteCount, charCount, lineCount, lineCharCount int) {
 	t.Run(fmt.Sprintf("Scan %s 0x%x", input, input), func(t *testing.T) {
 		b := bytes.NewBufferString(input)
 		s := NewScanner(b)
 		tok, lit, err := s.Scan()
 		require.NoError(t, err)
 		require.Equal(t, token, tok)
-		require.Equal(t, input, lit)
+		require.Equal(t, output, lit)
 		require.Equalf(t, byteCount, s.byteCount, "byteCount")
 		require.Equalf(t, charCount, s.charCount, "charCount")
 		require.Equalf(t, lineCount, s.lineCount, "lineCount")
@@ -176,12 +176,19 @@ func assertScanned(t *testing.T, input string, token Token, byteCount, charCount
 }
 
 func TestScannerScan(t *testing.T) {
-	assertScanned(t, "(", LPAREN, 1, 1, 1, 1)
-	assertScanned(t, ")", RPAREN, 1, 1, 1, 1)
-	assertScanned(t, " ", WHITESPACE, 1, 1, 1, 1)
-	assertScanned(t, "\t", WHITESPACE, 1, 1, 1, 1)
-	assertScanned(t, "\r", WHITESPACE, 1, 1, 1, 1)
-	assertScanned(t, "\n", WHITESPACE, 1, 1, 2, 0)
-	assertScanned(t, "\v", WHITESPACE, 1, 1, 1, 1)
-	assertScanned(t, "\f", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "(", "(", LPAREN, 1, 1, 1, 1)
+	assertScanned(t, ")", ")", RPAREN, 1, 1, 1, 1)
+	assertScanned(t, " ", " ", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "\t", "\t", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "\r", "\r", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "\n", "\n", WHITESPACE, 1, 1, 2, 0)
+	assertScanned(t, "\v", "\v", WHITESPACE, 1, 1, 1, 1)
+	assertScanned(t, "\f", "\f", WHITESPACE, 1, 1, 1, 1)
+}
+
+func TestScannerScanContiguousWhitespace(t *testing.T) {
+	// Terminated by EOF
+	assertScanned(t, "  ", "  ", WHITESPACE, 2, 2, 1, 2)
+	// Terminated by non-whitespace char
+	assertScanned(t, "  (", "  ", WHITESPACE, 2, 2, 1, 2)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -218,4 +218,6 @@ func TestScannerScan(t *testing.T) {
 	assertScanned(t, "1", "1", NUMBER, 1, 1, 1, 1)
 	// - Single digit integer, terminated by non-number character
 	assertScanned(t, "1)", "1", NUMBER, 1, 1, 1, 1)
+	// - Multi digit integer, EOF terminated
+	assertScanned(t, "998989", "998989", NUMBER, 6, 6, 1, 6)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -160,7 +160,7 @@ func TestNewScanner(t *testing.T) {
 	require.Equal(t, expected, content)
 }
 
-func assertScanned(t *testing.T, input string, token Token) {
+func assertScanned(t *testing.T, input string, token Token, byteCount, charCount, lineCount, lineCharCount int) {
 	t.Run(fmt.Sprintf("Scan %s", input), func(t *testing.T) {
 		b := bytes.NewBufferString(input)
 		s := NewScanner(b)
@@ -168,10 +168,15 @@ func assertScanned(t *testing.T, input string, token Token) {
 		require.NoError(t, err)
 		require.Equal(t, token, tok)
 		require.Equal(t, input, lit)
+		require.Equal(t, byteCount, s.byteCount)
+		require.Equal(t, charCount, s.charCount)
+		require.Equal(t, lineCount, s.lineCount)
+		require.Equal(t, lineCharCount, s.lineCharCount)
 	})
 }
 
 func TestScannerScan(t *testing.T) {
-	assertScanned(t, "(", LPAREN)
-	assertScanned(t, ")", RPAREN)
+	assertScanned(t, "(", LPAREN, 1, 1, 1, 1)
+	assertScanned(t, ")", RPAREN, 1, 1, 1, 1)
+	assertScanned(t, " ", WHITESPACE, 1, 1, 1, 1)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -244,11 +244,31 @@ func TestScannerScanNumber(t *testing.T) {
 }
 
 func TestScannerScanBool(t *testing.T) {
+	// Happy cases
+	// - true,  EOF Terminated
 	assertScanned(t, "#true", "true", BOOL, 5, 5, 1, 5)
-	assertScanned(t, "#false", "false", BOOL, 6, 6, 1, 6)
+	// - false, newline terminated
+	assertScanned(t, "#false\n", "false", BOOL, 7, 7, 2, 0)
+	// Sad cases
+	// - partial true
 	assertScanFailed(t, "#tru ", "Error:1,4: invalid boolean: tru")
+	// - partial false
 	assertScanFailed(t, "#fa)", "Error:1,3: invalid boolean: fa")
+	// - invalid
 	assertScanFailed(t, "#1", "Error:1,1: invalid boolean")
+	// - repeated signal character
 	assertScanFailed(t, "##", "Error:1,1: invalid boolean")
+	// - empty
 	assertScanFailed(t, "#", "Error:1,1: invalid boolean")
+}
+
+func TestScannerScanComment(t *testing.T) {
+	// Simple empty comment at EOF
+	assertScanned(t, ";", "", COMMENT, 1, 1, 1, 1)
+	// Comment terminated by newline
+	assertScanned(t, "; Foo\nbar", " Foo", COMMENT, 6, 6, 2, 0)
+	// Comment containing Comment char
+	assertScanned(t, ";Pants;On;Fire", "Pants;On;Fire", COMMENT, 14, 14, 1, 14)
+	// Comment containing control characters
+	assertScanned(t, `;()"-#1`, `()"-#1`, COMMENT, 7, 7, 1, 7)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -257,7 +257,7 @@ func TestScannerScanBool(t *testing.T) {
 	// - true,  EOF Terminated
 	assertScanned(t, "#true", "true", BOOL, 5, 5, 1, 5)
 	// - false, newline terminated
-	assertScanned(t, "#false\n", "false", BOOL, 7, 7, 2, 0)
+	assertScanned(t, "#false\n", "false", BOOL, 6, 6, 1, 7)
 	// Sad cases
 	// - partial true
 	assertScanFailed(t, "#tru ", "Error:1,4: invalid boolean: tru")

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -216,10 +216,19 @@ func TestScannerScan(t *testing.T) {
 	// Test number
 	// - Single digit integer, EOF terminated
 	assertScanned(t, "1", "1", NUMBER, 1, 1, 1, 1)
-	// - Single digit integer, terminated by non-number character
+	// - Single digit integer, terminated by non-numeric character
 	assertScanned(t, "1)", "1", NUMBER, 1, 1, 1, 1)
 	// - Multi-digit integer, EOF terminated
 	assertScanned(t, "998989", "998989", NUMBER, 6, 6, 1, 6)
 	// - Negative multi-digit integer, EOF terminated
 	assertScanned(t, "-100", "-100", NUMBER, 4, 4, 1, 4)
+	// - Floating point number, EOF terminated
+	assertScanned(t, "2.4", "2.4", NUMBER, 3, 3, 1, 3)
+	// - long negative float, terminated by non-numeric character
+	assertScanned(t, "-123.45456 ", "-123.45456", NUMBER, 10, 10, 1, 10)
+	// - special case: a "-" without a number following it (as per the minus operator)
+	assertScanned(t, "- 1 2", "-", SYMBOL, 1, 1, 1, 1)
+	// - sad case: a minus mid-number
+	assertScanFailed(t, "1-2", "Error:1,2: invalid number format (minus can only appear at the beginning of a number)")
+	assertScanFailed(t, "-", "Error:1,1: EOF")
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -301,6 +301,7 @@ func TestScannerScanSymbol(t *testing.T) {
 	assertScanned(t, "-", "-", SYMBOL, 1, 1, 1, 1)
 }
 
+// Scanner.Scan can scan a full symbollic expression sequence.
 func TestScannerScanSequence(t *testing.T) {
 	input := `
 (and
@@ -338,4 +339,16 @@ func TestScannerScanSequence(t *testing.T) {
 	assertScannerScanned(t, s, " ", WHITESPACE, 58, 58, 4, 35)
 	assertScannerScanned(t, s, " Crazy", COMMENT, 66, 66, 5, 0)
 	assertScannerScanned(t, s, "", EOF, 66, 66, 5, 0)
+}
+
+func TestScannerScanReturnsScanError(t *testing.T) {
+	input := `
+(= "toffee`
+	b := bytes.NewBufferString(input)
+	s := NewScanner(b)
+	assertScannerScanned(t, s, "\n", WHITESPACE, 1, 1, 2, 0)
+	assertScannerScanned(t, s, "(", LPAREN, 2, 2, 2, 1)
+	assertScannerScanned(t, s, "=", SYMBOL, 3, 3, 2, 2)
+	assertScannerScanned(t, s, " ", WHITESPACE, 4, 4, 2, 3)
+	assertScannerScanFailed(t, s, "Error:2,10: unterminated string constant")
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -1,6 +1,8 @@
 package sexpr
 
 import (
+	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -144,5 +146,15 @@ func TestIsSymbol(t *testing.T) {
 	require.False(t, isSymbol(')'))
 	require.False(t, isSymbol('('))
 	require.False(t, isSymbol('0'))
+}
 
+// NewScanner wraps an io.Reader
+func TestNewScanner(t *testing.T) {
+	expected := "(+ 1 1)"
+	b := bytes.NewBufferString(expected)
+	s := NewScanner(b)
+	content, err := s.r.ReadString('\n')
+	require.Error(t, err)
+	require.Equal(t, io.EOF, err)
+	require.Equal(t, expected, content)
 }

--- a/rule/sexpr/lexer_internal_test.go
+++ b/rule/sexpr/lexer_internal_test.go
@@ -158,3 +158,14 @@ func TestNewScanner(t *testing.T) {
 	require.Equal(t, io.EOF, err)
 	require.Equal(t, expected, content)
 }
+
+func TestScannerScan(t *testing.T) {
+	expected := "("
+	b := bytes.NewBufferString(expected)
+	s := NewScanner(b)
+	tok, lit, err := s.Scan()
+	require.NoError(t, err)
+	require.Equal(t, tok, LPAREN)
+	require.Equal(t, lit, "(")
+
+}


### PR DESCRIPTION
This PR defines the scanner for the symbollic expression language to be deployed in the Regula UI.

There are essentially 3 layers to this:
  - A `Scanner` struct that wraps a `io.Reader` in a `bufio.Reader` and uses it to read the stream a rune at a time (supporting backtracking as needed).  
- The scanner provides primitives to `readRune` and `unreadRune` which wrap the `bufio.Reader` methods of the same name - maintaining positional information as they go.
- The `Scanner.Scan` method grabs the next rune and identifies it.  If it is a simple control character (i.e. parenthesis) it returns the token for that control character.  If it implies a contiguous block, it hands this work off to a specialised scan function.

The specialised scan functions make up the bulk of the work.  Mostly they are simply looping looking for a character that terminates the sequence.  `scanNumber` however is somewhat more complex.  I have chosen to handle the conflict between the use of `-` to indicate a negative number and it's use as an operator in this part of the code.  This decision makes the scanner more complicated, but simplifies things in the parser we will add later - we have to make one of these two layers somewhat "impure" so I chose to do it at the more fundamental of the two, meaning the parser can be implemented without this wart.  

Fixes: #16 
