### PR TITLE
Define ComparableExpression interface

### DIFF
--- a/rule/expr.go
+++ b/rule/expr.go
@@ -8,7 +8,6 @@ import (
 
 // An Expr is a logical expression that can be evaluated to a value.
 type Expr interface {
-	ComparableExpression
 	Eval(Params) (*Value, error)
 }
 

--- a/rule/expr.go
+++ b/rule/expr.go
@@ -31,14 +31,14 @@ type Params interface {
 }
 
 type exprNot struct {
-	*operator
+	operator
 }
 
 // Not creates an expression that evaluates the given operand e and returns its opposite.
 // e must evaluate to a boolean.
 func Not(e Expr) Expr {
 	return &exprNot{
-		operator: &operator{
+		operator: operator{
 			kind:     "not",
 			operands: []Expr{e},
 		},

--- a/rule/expr_test.go
+++ b/rule/expr_test.go
@@ -242,19 +242,19 @@ func TestExprSame(t *testing.T) {
 	expr1 := rule.Eq(
 		rule.Int64Value(1),
 		rule.Int64Value(1),
-	)
+	).(rule.ComparableExpression)
 	expr2 := rule.Eq(
 		rule.Int64Value(1),
 		rule.Int64Value(1),
-	)
+	).(rule.ComparableExpression)
 	expr3 := rule.Eq(
 		rule.Int64Value(1),
 		rule.Int64Value(2),
-	)
+	).(rule.ComparableExpression)
 	expr4 := rule.And(
 		rule.BoolValue(true),
 		rule.BoolValue(true),
-	)
+	).(rule.ComparableExpression)
 
 	assert.True(t, expr1.Same(expr2))
 	assert.False(t, expr1.Same(expr3))
@@ -276,7 +276,7 @@ func TestExprTreeSame(t *testing.T) {
 			rule.BoolValue(true),
 		),
 		rule.BoolValue(false),
-	)
+	).(rule.ComparableExpression)
 	expr2 := rule.Eq(
 		rule.And(
 			rule.And(
@@ -291,7 +291,7 @@ func TestExprTreeSame(t *testing.T) {
 			rule.BoolValue(true),
 		),
 		rule.BoolValue(false),
-	)
+	).(rule.ComparableExpression)
 
 	expr3 := rule.Eq(
 		rule.And(
@@ -307,7 +307,7 @@ func TestExprTreeSame(t *testing.T) {
 			rule.BoolValue(false),
 		),
 		rule.BoolValue(false),
-	)
+	).(rule.ComparableExpression)
 
 	assert.True(t, expr1.Same(expr1))
 	assert.False(t, expr1.Same(expr2))

--- a/rule/expr_test.go
+++ b/rule/expr_test.go
@@ -237,6 +237,7 @@ func TestValue(t *testing.T) {
 	require.False(t, v1.Equal(rule.StringValue("true")))
 }
 
+// A ComparableExpression can check its equivalence to another ComparableExpression
 func TestExprSame(t *testing.T) {
 	expr1 := rule.Eq(
 		rule.Int64Value(1),
@@ -260,6 +261,7 @@ func TestExprSame(t *testing.T) {
 	assert.False(t, expr1.Same(expr4))
 }
 
+// A ComparableExpression can check it equivalence to a complete AST.
 func TestExprTreeSame(t *testing.T) {
 	expr1 := rule.Eq(
 		rule.And(
@@ -310,4 +312,24 @@ func TestExprTreeSame(t *testing.T) {
 	assert.True(t, expr1.Same(expr1))
 	assert.False(t, expr1.Same(expr2))
 	assert.False(t, expr1.Same(expr3))
+}
+
+// A Value is a ComparableExpression
+func TestValueSameness(t *testing.T) {
+	v1 := rule.StringValue("foo")
+	v2 := rule.StringValue("bar")
+	v3 := rule.Int64Value(42)
+	require.True(t, v1.Same(v1))
+	require.False(t, v1.Same(v2))
+	require.False(t, v1.Same(v3))
+}
+
+// A Param is a ComparableExpression
+func TestParamSameness(t *testing.T) {
+	p1 := rule.StringParam("bob")
+	p2 := rule.StringParam("dave")
+	p3 := rule.Float64Param("bob")
+	require.True(t, p1.Same(p1))
+	require.False(t, p1.Same(p2))
+	require.False(t, p1.Same(p3))
 }

--- a/rule/expr_test.go
+++ b/rule/expr_test.go
@@ -309,9 +309,12 @@ func TestExprTreeSame(t *testing.T) {
 		rule.BoolValue(false),
 	).(rule.ComparableExpression)
 
+	expr4 := rule.Not(rule.BoolValue(false)).(rule.ComparableExpression)
+
 	assert.True(t, expr1.Same(expr1))
 	assert.False(t, expr1.Same(expr2))
 	assert.False(t, expr1.Same(expr3))
+	assert.False(t, expr1.Same(expr4))
 }
 
 // A Value is a ComparableExpression

--- a/rule/json.go
+++ b/rule/json.go
@@ -23,7 +23,9 @@ func (o *operator) Same(c ComparableExpression) bool {
 				return false
 			}
 			for i := 0; i < len1; i++ {
-				if !o.operands[i].Same(ops[i]) {
+				ce1 := o.operands[i].(ComparableExpression)
+				ce2 := ops[i].(ComparableExpression)
+				if !ce1.Same(ce2) {
 					return false
 				}
 			}

--- a/rule/json.go
+++ b/rule/json.go
@@ -12,6 +12,33 @@ type operator struct {
 	operands []Expr
 }
 
+func (o *operator) Same(c ComparableExpression) bool {
+	if o.kind == c.GetKind() {
+		o2, ok := c.(operander)
+		if ok {
+			ops := o2.Operands()
+			len1 := len(o.operands)
+			len2 := len(ops)
+			if len1 != len2 {
+				return false
+			}
+			for i := 0; i < len1; i++ {
+				if !o.operands[i].Same(ops[i]) {
+					return false
+				}
+			}
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+//
+func (o *operator) GetKind() string {
+	return o.kind
+}
+
 func (o *operator) UnmarshalJSON(data []byte) error {
 	var node struct {
 		Kind     string

--- a/rule/json_test.go
+++ b/rule/json_test.go
@@ -173,8 +173,8 @@ func TestRuleUnmarshalling(t *testing.T) {
 // An operator is a ComparableExpression
 func TestOperatorSameness(t *testing.T) {
 	o1 := &operator{kind: "not", operands: []Expr{BoolValue(true)}}
-	o2 := Not(BoolValue(true))
-	o3 := Or(BoolValue(true), BoolValue(false))
+	o2 := Not(BoolValue(true)).(ComparableExpression)
+	o3 := Or(BoolValue(true), BoolValue(false)).(ComparableExpression)
 	require.True(t, o1.Same(o2))
 	require.False(t, o1.Same(o3))
 }

--- a/rule/json_test.go
+++ b/rule/json_test.go
@@ -169,3 +169,11 @@ func TestRuleUnmarshalling(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestOperatorSameness(t *testing.T) {
+	o1 := &operator{kind: "not", operands: []Expr{BoolValue(true)}}
+	o2 := Not(BoolValue(true))
+	o3 := Or(BoolValue(true), BoolValue(false))
+	require.True(t, o1.Same(o2))
+	require.False(t, o1.Same(o3))
+}

--- a/rule/json_test.go
+++ b/rule/json_test.go
@@ -170,6 +170,7 @@ func TestRuleUnmarshalling(t *testing.T) {
 	})
 }
 
+// An operator is a ComparableExpression
 func TestOperatorSameness(t *testing.T) {
 	o1 := &operator{kind: "not", operands: []Expr{BoolValue(true)}}
 	o2 := Not(BoolValue(true))


### PR DESCRIPTION
The PR sets up a `ComparableExpression` interface that allows us to ask if an `rule.Expr` is equivalent to another `rule.Expr`.  This definition is recursive, and thus we can use it to compare a full AST or any subset.  This is required so that we can make assertions about generated ASTs that result from the forthcoming symbollic expression parser - without it we would need to make the expression, value and param types public which is undesirable.

This is groundwork to enable progress on: https://github.com/heetch/regula/issues/17