### PR TITLE
rules: Add Type, Cardinality, Term, Contract and TypedExpression

### DIFF
--- a/rule/contract.go
+++ b/rule/contract.go
@@ -1,0 +1,59 @@
+package rule
+
+// Type represents the type of a typed expression.  Any expression has
+// a return type, and some expressions also receive typed parameters.
+type Type int
+
+// These constants represent the complete set of abstract types usable
+// in expressions within Regula.  Not that these abstract types don't
+// necessary equate directly to concrete types that you might think
+// about within Go.  In particular "NUMBER" and "ANY" exist to define
+// parameters that do not have to be of a fixed type.
+const (
+	BOOLEAN Type = iota
+	STRING
+	INTEGER
+	FLOAT
+	NUMBER // A special type that can be promoted to INTEGER or FLOAT
+	ANY    // A special type that can be promoted to any other.
+)
+
+// Cardinality expresses the number of times a term might be repeated
+// in an expression.
+type Cardinality int
+
+// These constants define the complete set of cardinality possible for
+// terms of a contract.  We can expect a term to occur exactly once
+// (ONE), or zero, one or many times (MANY).
+const (
+	MANY = 0
+	ONE  = 1
+)
+
+type Term struct {
+	Type        Type
+	Cardinality Cardinality
+}
+
+// IsFulfilledBy returns true when a provided TypedExpression has a return type
+// that matches the Term's Type.
+func (t Term) IsFulfilledBy(te TypedExpression) bool {
+	return te.Contract().ReturnType == t.Type
+}
+
+// A Contract declares the Type compatibility of an expression.  Every
+// expression has a ReturnType (it's value type, in place when
+// evaluated) and zero, one or many Terms.  Each Term is in turn
+// typed, and has a defined cardinality.
+type Contract struct {
+	ReturnType Type
+	Terms      []Term
+}
+
+// A TypedExpression is an expression that declares the Type Contract
+// it makes with the context in which it appears, and with any
+// sub-expressions that it contains.  This Contract can be inspected
+// by called the Contract method of the TypedExpression interface.
+type TypedExpression interface {
+	Contract() Contract
+}

--- a/rule/contract.go
+++ b/rule/contract.go
@@ -38,7 +38,15 @@ type Term struct {
 // IsFulfilledBy returns true when a provided TypedExpression has a return type
 // that matches the Term's Type.
 func (t Term) IsFulfilledBy(te TypedExpression) bool {
-	return te.Contract().ReturnType == t.Type
+	rt := te.Contract().ReturnType
+	// Switch to handle promotable abstract types.
+	switch t.Type {
+	case ANY:
+		return true
+	case NUMBER:
+		return rt == INTEGER || rt == FLOAT
+	}
+	return rt == t.Type
 }
 
 // A Contract declares the Type compatibility of an expression.  Every

--- a/rule/contract.go
+++ b/rule/contract.go
@@ -30,6 +30,11 @@ const (
 	ONE  = 1
 )
 
+// Term represents the contract for an operand, or for a repeated
+// sequence of operands.  A term can be fulfilled by a Value, Param or
+// Expr, so long as their own Contract specifies a ReturnType that
+// matches the Term's Type, or can be promoted to that Type.  Every
+// Term also has Cardinality.
 type Term struct {
 	Type        Type
 	Cardinality Cardinality

--- a/rule/contract_test.go
+++ b/rule/contract_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// IsFulfilledBy indicates whether a given TypedExpression fulfils a Term.
 func TestTermIsFulfilledBy(t *testing.T) {
 	// We'll express a few fundamental TypedExpressions, to avoid repetition in the test cases.
 	boolean := rule.BoolValue(true)

--- a/rule/contract_test.go
+++ b/rule/contract_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestTermIsFulfilledBy(t *testing.T) {
+	// We'll express a few fundamental TypedExpressions, to avoid repetition in the test cases.
 	boolean := rule.BoolValue(true)
 	integer := rule.Int64Value(1)
 	float := rule.Float64Value(1.1)
@@ -17,8 +18,17 @@ func TestTermIsFulfilledBy(t *testing.T) {
 	stringParam := rule.StringParam("foo")
 	intParam := rule.Int64Param("foo")
 	floatParam := rule.Float64Param("foo")
+	not := rule.Not(boolean).(rule.TypedExpression)
+	or := rule.Or(boolean, boolean).(rule.TypedExpression)
+	and := rule.And(boolean, boolean).(rule.TypedExpression)
+	eq := rule.Eq(boolean, boolean).(rule.TypedExpression)
+	in := rule.In(boolean, boolean, boolean).(rule.TypedExpression)
 
 	testCases := []struct {
+		// Test cases define a list of positive expressions
+		// (those that fulfil the Term), and a list of
+		// negative expressions (those that do not fulfil the
+		// Term).  We are attempting to be exhaustive here.
 		name                string
 		positiveExpressions []rule.TypedExpression
 		negativeExpressions []rule.TypedExpression
@@ -27,85 +37,38 @@ func TestTermIsFulfilledBy(t *testing.T) {
 		{
 			name: "Boolean",
 			positiveExpressions: []rule.TypedExpression{
-				boolean,
-				boolParam,
-				rule.Not(boolean).(rule.TypedExpression),
-				rule.Or(boolean, boolean).(rule.TypedExpression),
-				rule.And(boolean, boolean).(rule.TypedExpression),
-				rule.Eq(boolean, boolean).(rule.TypedExpression),
-				rule.In(boolean, boolean, boolean).(rule.TypedExpression),
-			},
+				boolean, boolParam, not, or, and, eq, in},
 			negativeExpressions: []rule.TypedExpression{
-				str,
-				integer,
-				float,
-				stringParam,
-				intParam,
-				floatParam,
-			},
+				str, integer, float, stringParam, intParam, floatParam},
 			term: rule.Term{Type: rule.BOOLEAN},
 		},
 		{
-			name: "String",
-			positiveExpressions: []rule.TypedExpression{
-				str,
-				stringParam,
-			},
+			name:                "String",
+			positiveExpressions: []rule.TypedExpression{str, stringParam},
 			negativeExpressions: []rule.TypedExpression{
-				boolean,
-				integer,
-				float,
-				boolParam,
-				intParam,
-				floatParam,
-				rule.Or(boolean, boolean).(rule.TypedExpression),
-				rule.And(boolean, boolean).(rule.TypedExpression),
-				rule.Eq(boolean, boolean).(rule.TypedExpression),
-				rule.In(boolean, boolean, boolean).(rule.TypedExpression),
-			},
+				boolean, integer, float, boolParam, intParam, floatParam,
+				or, and, eq, in},
 			term: rule.Term{Type: rule.STRING},
 		},
 		{
-			name: "Integer",
-			positiveExpressions: []rule.TypedExpression{
-				integer,
-				intParam,
-			},
+			name:                "Integer",
+			positiveExpressions: []rule.TypedExpression{integer, intParam},
 			negativeExpressions: []rule.TypedExpression{
-				boolean,
-				str,
-				float,
-				boolParam,
-				stringParam,
-				floatParam,
-				rule.Or(boolean, boolean).(rule.TypedExpression),
-				rule.And(boolean, boolean).(rule.TypedExpression),
-				rule.Eq(boolean, boolean).(rule.TypedExpression),
-				rule.In(boolean, boolean, boolean).(rule.TypedExpression),
-			},
+				boolean, str, float, boolParam, stringParam, floatParam,
+				or, and, eq, in},
 			term: rule.Term{Type: rule.INTEGER},
 		},
 		{
-			name: "Float",
-			positiveExpressions: []rule.TypedExpression{
-				float,
-				floatParam,
-			},
+			name:                "Float",
+			positiveExpressions: []rule.TypedExpression{float, floatParam},
 			negativeExpressions: []rule.TypedExpression{
-				boolean,
-				str,
-				integer,
-				boolParam,
-				stringParam,
-				intParam,
-				rule.Or(boolean, boolean).(rule.TypedExpression),
-				rule.And(boolean, boolean).(rule.TypedExpression),
-				rule.Eq(boolean, boolean).(rule.TypedExpression),
-				rule.In(boolean, boolean, boolean).(rule.TypedExpression),
-			},
+				boolean, str, integer, boolParam, stringParam, intParam,
+				or, and, eq, in},
 			term: rule.Term{Type: rule.FLOAT},
 		},
 	}
+
+	// Run "IsFullfilledBy" for each test case with each positive and negative expression.
 	for i, tc := range testCases {
 		for j, pc := range tc.positiveExpressions {
 			t.Run(fmt.Sprintf("%s[%d] positive case %d", tc.name, i, j),

--- a/rule/contract_test.go
+++ b/rule/contract_test.go
@@ -75,6 +75,16 @@ func TestTermIsFulfilledBy(t *testing.T) {
 			},
 			term: rule.Term{Type: rule.NUMBER},
 		},
+		{
+			name: "Any",
+			positiveExpressions: []rule.TypedExpression{
+				integer, intParam, float, floatParam,
+				boolean, str, boolParam, stringParam,
+				or, and, eq, not,
+			},
+			negativeExpressions: nil,
+			term:                rule.Term{Type: rule.ANY},
+		},
 	}
 
 	// Run "IsFullfilledBy" for each test case with each positive and negative expression.

--- a/rule/contract_test.go
+++ b/rule/contract_test.go
@@ -47,7 +47,7 @@ func TestTermIsFulfilledBy(t *testing.T) {
 			positiveExpressions: []rule.TypedExpression{str, stringParam},
 			negativeExpressions: []rule.TypedExpression{
 				boolean, integer, float, boolParam, intParam, floatParam,
-				or, and, eq, in},
+				or, and, eq, in, not},
 			term: rule.Term{Type: rule.STRING},
 		},
 		{
@@ -55,7 +55,7 @@ func TestTermIsFulfilledBy(t *testing.T) {
 			positiveExpressions: []rule.TypedExpression{integer, intParam},
 			negativeExpressions: []rule.TypedExpression{
 				boolean, str, float, boolParam, stringParam, floatParam,
-				or, and, eq, in},
+				or, and, eq, in, not},
 			term: rule.Term{Type: rule.INTEGER},
 		},
 		{
@@ -63,8 +63,17 @@ func TestTermIsFulfilledBy(t *testing.T) {
 			positiveExpressions: []rule.TypedExpression{float, floatParam},
 			negativeExpressions: []rule.TypedExpression{
 				boolean, str, integer, boolParam, stringParam, intParam,
-				or, and, eq, in},
+				or, and, eq, in, not},
 			term: rule.Term{Type: rule.FLOAT},
+		},
+		{
+			name: "Number",
+			positiveExpressions: []rule.TypedExpression{
+				integer, intParam, float, floatParam},
+			negativeExpressions: []rule.TypedExpression{
+				boolean, str, boolParam, stringParam, or, and, eq, not,
+			},
+			term: rule.Term{Type: rule.NUMBER},
 		},
 	}
 

--- a/rule/contract_test.go
+++ b/rule/contract_test.go
@@ -1,0 +1,103 @@
+package rule_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/heetch/regula/rule"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTermIsFulfilledBy(t *testing.T) {
+	boolean := rule.BoolValue(true)
+	integer := rule.Int64Value(1)
+	float := rule.Float64Value(1.1)
+	str := rule.StringValue("foo")
+
+	testCases := []struct {
+		name                string
+		positiveExpressions []rule.TypedExpression
+		negativeExpressions []rule.TypedExpression
+		term                rule.Term
+	}{
+		{
+			name: "Boolean",
+			positiveExpressions: []rule.TypedExpression{
+				boolean,
+				rule.Not(boolean).(rule.TypedExpression),
+				rule.Or(boolean, boolean).(rule.TypedExpression),
+				rule.And(boolean, boolean).(rule.TypedExpression),
+				rule.Eq(boolean, boolean).(rule.TypedExpression),
+				rule.In(boolean, boolean, boolean).(rule.TypedExpression),
+			},
+			negativeExpressions: []rule.TypedExpression{
+				str,
+				integer,
+				float,
+			},
+			term: rule.Term{Type: rule.BOOLEAN},
+		},
+		{
+			name: "String",
+			positiveExpressions: []rule.TypedExpression{
+				str,
+			},
+			negativeExpressions: []rule.TypedExpression{
+				boolean,
+				integer,
+				float,
+				rule.Or(boolean, boolean).(rule.TypedExpression),
+				rule.And(boolean, boolean).(rule.TypedExpression),
+				rule.Eq(boolean, boolean).(rule.TypedExpression),
+				rule.In(boolean, boolean, boolean).(rule.TypedExpression),
+			},
+			term: rule.Term{Type: rule.STRING},
+		},
+		{
+			name: "Integer",
+			positiveExpressions: []rule.TypedExpression{
+				integer,
+			},
+			negativeExpressions: []rule.TypedExpression{
+				boolean,
+				str,
+				float,
+				rule.Or(boolean, boolean).(rule.TypedExpression),
+				rule.And(boolean, boolean).(rule.TypedExpression),
+				rule.Eq(boolean, boolean).(rule.TypedExpression),
+				rule.In(boolean, boolean, boolean).(rule.TypedExpression),
+			},
+			term: rule.Term{Type: rule.INTEGER},
+		},
+		{
+			name: "Float",
+			positiveExpressions: []rule.TypedExpression{
+				float,
+			},
+			negativeExpressions: []rule.TypedExpression{
+				boolean,
+				str,
+				integer,
+				rule.Or(boolean, boolean).(rule.TypedExpression),
+				rule.And(boolean, boolean).(rule.TypedExpression),
+				rule.Eq(boolean, boolean).(rule.TypedExpression),
+				rule.In(boolean, boolean, boolean).(rule.TypedExpression),
+			},
+			term: rule.Term{Type: rule.FLOAT},
+		},
+	}
+	for i, tc := range testCases {
+		for j, pc := range tc.positiveExpressions {
+			t.Run(fmt.Sprintf("%s[%d] positive case %d", tc.name, i, j),
+				func(t *testing.T) {
+					require.True(t, tc.term.IsFulfilledBy(pc))
+				})
+		}
+		for k, nc := range tc.negativeExpressions {
+			t.Run(fmt.Sprintf("%s[%d] negative case %d", tc.name, i, k),
+				func(t *testing.T) {
+					require.False(t, tc.term.IsFulfilledBy(nc))
+				})
+		}
+	}
+}

--- a/rule/contract_test.go
+++ b/rule/contract_test.go
@@ -13,6 +13,10 @@ func TestTermIsFulfilledBy(t *testing.T) {
 	integer := rule.Int64Value(1)
 	float := rule.Float64Value(1.1)
 	str := rule.StringValue("foo")
+	boolParam := rule.BoolParam("foo")
+	stringParam := rule.StringParam("foo")
+	intParam := rule.Int64Param("foo")
+	floatParam := rule.Float64Param("foo")
 
 	testCases := []struct {
 		name                string
@@ -24,6 +28,7 @@ func TestTermIsFulfilledBy(t *testing.T) {
 			name: "Boolean",
 			positiveExpressions: []rule.TypedExpression{
 				boolean,
+				boolParam,
 				rule.Not(boolean).(rule.TypedExpression),
 				rule.Or(boolean, boolean).(rule.TypedExpression),
 				rule.And(boolean, boolean).(rule.TypedExpression),
@@ -34,6 +39,9 @@ func TestTermIsFulfilledBy(t *testing.T) {
 				str,
 				integer,
 				float,
+				stringParam,
+				intParam,
+				floatParam,
 			},
 			term: rule.Term{Type: rule.BOOLEAN},
 		},
@@ -41,11 +49,15 @@ func TestTermIsFulfilledBy(t *testing.T) {
 			name: "String",
 			positiveExpressions: []rule.TypedExpression{
 				str,
+				stringParam,
 			},
 			negativeExpressions: []rule.TypedExpression{
 				boolean,
 				integer,
 				float,
+				boolParam,
+				intParam,
+				floatParam,
 				rule.Or(boolean, boolean).(rule.TypedExpression),
 				rule.And(boolean, boolean).(rule.TypedExpression),
 				rule.Eq(boolean, boolean).(rule.TypedExpression),
@@ -57,11 +69,15 @@ func TestTermIsFulfilledBy(t *testing.T) {
 			name: "Integer",
 			positiveExpressions: []rule.TypedExpression{
 				integer,
+				intParam,
 			},
 			negativeExpressions: []rule.TypedExpression{
 				boolean,
 				str,
 				float,
+				boolParam,
+				stringParam,
+				floatParam,
 				rule.Or(boolean, boolean).(rule.TypedExpression),
 				rule.And(boolean, boolean).(rule.TypedExpression),
 				rule.Eq(boolean, boolean).(rule.TypedExpression),
@@ -73,11 +89,15 @@ func TestTermIsFulfilledBy(t *testing.T) {
 			name: "Float",
 			positiveExpressions: []rule.TypedExpression{
 				float,
+				floatParam,
 			},
 			negativeExpressions: []rule.TypedExpression{
 				boolean,
 				str,
 				integer,
+				boolParam,
+				stringParam,
+				intParam,
 				rule.Or(boolean, boolean).(rule.TypedExpression),
 				rule.And(boolean, boolean).(rule.TypedExpression),
 				rule.Eq(boolean, boolean).(rule.TypedExpression),

--- a/rule/expr.go
+++ b/rule/expr.go
@@ -311,6 +311,9 @@ type Param struct {
 	Name string `json:"name"`
 }
 
+// Same compares the Param with a ComparableExpression to see if they
+// are identical.  This is required by the ComparableExpression
+// interface.
 func (p *Param) Same(c ComparableExpression) bool {
 	if p.Kind == c.GetKind() {
 		p2, ok := c.(*Param)
@@ -319,8 +322,27 @@ func (p *Param) Same(c ComparableExpression) bool {
 	return false
 }
 
+// GetKind returns the Param's Kind in the way required by the
+// ComparableExpression interface.
 func (p *Param) GetKind() string {
 	return p.Kind
+}
+
+// Contract returns the Contract of a param (which is simply a
+// ReturnType that matches the param).  Thus Params implement the
+// TypedExpression interface.
+func (p *Param) Contract() Contract {
+	switch p.Type {
+	case "bool":
+		return Contract{ReturnType: BOOLEAN}
+	case "string":
+		return Contract{ReturnType: STRING}
+	case "int64":
+		return Contract{ReturnType: INTEGER}
+	case "float64":
+		return Contract{ReturnType: FLOAT}
+	}
+	panic(fmt.Sprintf("invalid value type: %q", p.Type))
 }
 
 // StringParam creates a Param that looks up in the set of params passed during evaluation and returns the value

--- a/rule/expr.go
+++ b/rule/expr.go
@@ -2,6 +2,7 @@ package rule
 
 import (
 	"errors"
+	"fmt"
 	"go/token"
 	"strconv"
 )
@@ -66,6 +67,14 @@ func (n *exprNot) Eval(params Params) (*Value, error) {
 	return BoolValue(true), nil
 }
 
+// Contract returns the Contract for exprNot, and makes it comply with the TypedExpression interface.
+func (n *exprNot) Contract() Contract {
+	return Contract{
+		ReturnType: BOOLEAN,
+		Terms:      []Term{{Type: BOOLEAN, Cardinality: ONE}},
+	}
+}
+
 type exprOr struct {
 	operator
 }
@@ -114,6 +123,14 @@ func (n *exprOr) Eval(params Params) (*Value, error) {
 	}
 
 	return BoolValue(false), nil
+}
+
+// Contract returns the Contract for exprOr, and makes it comply with the TypedExpression interface.
+func (n *exprOr) Contract() Contract {
+	return Contract{
+		ReturnType: BOOLEAN,
+		Terms:      []Term{{Type: BOOLEAN, Cardinality: MANY}},
+	}
 }
 
 type exprAnd struct {
@@ -166,6 +183,19 @@ func (n *exprAnd) Eval(params Params) (*Value, error) {
 	return BoolValue(true), nil
 }
 
+// Contract returns the Contract for exprAnd, and makes it comply with the TypedExpression interface.
+func (n *exprAnd) Contract() Contract {
+	return Contract{
+		ReturnType: BOOLEAN,
+		Terms: []Term{
+			{
+				Type:        BOOLEAN,
+				Cardinality: MANY,
+			},
+		},
+	}
+}
+
 type exprEq struct {
 	operator
 }
@@ -205,6 +235,19 @@ func (n *exprEq) Eval(params Params) (*Value, error) {
 	return BoolValue(true), nil
 }
 
+// Contract returns the Contract for exprEq, and makes it comply with the TypedExpression interface.
+func (n *exprEq) Contract() Contract {
+	return Contract{
+		ReturnType: BOOLEAN,
+		Terms: []Term{
+			{
+				Type:        ANY,
+				Cardinality: MANY,
+			},
+		},
+	}
+}
+
 type exprIn struct {
 	operator
 }
@@ -242,6 +285,23 @@ func (n *exprIn) Eval(params Params) (*Value, error) {
 	}
 
 	return BoolValue(false), nil
+}
+
+// Contract returns the Contract for exprIn, and makes it comply with the TypedExpression interface.
+func (n *exprIn) Contract() Contract {
+	return Contract{
+		ReturnType: BOOLEAN,
+		Terms: []Term{
+			{
+				Type:        ANY,
+				Cardinality: ONE,
+			},
+			{
+				Type:        ANY,
+				Cardinality: MANY,
+			},
+		},
+	}
 }
 
 // Param is an expression used to select a parameter passed during evaluation and return its corresponding value.
@@ -363,19 +423,36 @@ func newValue(typ, data string) *Value {
 	}
 }
 
-//
+// Compares a Value with a ComparableExpression, without evaluating
+// either.  This is required by the ComparableExpression interface.
 func (v *Value) Same(c ComparableExpression) bool {
 	if v.Kind == c.GetKind() {
 		v2, ok := c.(*Value)
 		return ok && v.Type == v2.Type && v.Data == v2.Data
 	}
 	return false
-
 }
 
-//
+// GetKind returns the Value's kind, and is required by the ComparableExpression interface.
 func (v *Value) GetKind() string {
 	return v.Kind
+}
+
+// Contract returns the Contract of a value (which is simply a
+// ReturnType that matches the value).  Thus Values implement the
+// TypedExpression interface.
+func (v *Value) Contract() Contract {
+	switch v.Type {
+	case "bool":
+		return Contract{ReturnType: BOOLEAN}
+	case "string":
+		return Contract{ReturnType: STRING}
+	case "int64":
+		return Contract{ReturnType: INTEGER}
+	case "float64":
+		return Contract{ReturnType: FLOAT}
+	}
+	panic(fmt.Sprintf("invalid value type: %q", v.Type))
 }
 
 // BoolValue creates a bool type value.


### PR DESCRIPTION
This PR lays further groundwork for the s-expression Parser. ( #17 )

I have defined contracts for `Expr`, `Value` and `Param` types.   These contracts will be used by the parser to perform type checking on the tree of s-expressions.  We will parse the tree recursively, when we reach a leaf-node in the tree we will check it's `Contract.ReturnType` against the expected `Type` of the `Term` it is providing for the enclosing `Expr`.  This essentially makes our language statically typed (but type is inferred), with the inherent advantage of being able to capture programming errors (e.g. calling "not" on a string) prior to evaluation.

Note that when we talk about Type here, there are abstract types understood when parsing the language, not the concrete types that appear at runtime.  Which is to say, abstractly you can require that a parameter (Term) be a `NUMBER` or  `ANY`, but in practice this will always be something concrete like a Float64 or a string. 

We may later add a "Homogeneous" flag to `Term` to allow us to specify that, for example, "eq" requires that all of its arguments be of the same type (but accepts any type).  Not however that homogeny checking will happen in the Parser not in the Contract (or at least, it would have to be triggered by the parser).  