### PR TITLE
Allow the http server mux to be replaced before running the server

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -32,7 +32,7 @@ func New(service store.RulesetService, cfg Config) *Server {
 
 	srv.logger = *cfg.Logger
 
-	srv.server = &http.Server{Handler: srv.Mux}
+	srv.server = new(http.Server)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// cancel context on shutdown to stop long running operations like watches.
@@ -46,6 +46,8 @@ func New(service store.RulesetService, cfg Config) *Server {
 // Run runs the server on the chosen address. The given context must be used to
 // gracefully stop the server.
 func (s *Server) Run(ctx context.Context, addr string) error {
+	s.server.Handler = s.Mux
+
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR allows replacing the router from outside of Regula.

Previously, it was only possible to add routes to it and not replace it with another one from the outside because it was already assigned to the http server (l35).

This change assigns the router to the server only when we want to run the server (l49).

This is useful for being able to wrap the entire server and collect metrics for every request for example.
