### PR TITLE
New ruleset page

### DIFF
--- a/api/client/rulesets_test.go
+++ b/api/client/rulesets_test.go
@@ -354,7 +354,7 @@ func TestRulesetService(t *testing.T) {
 		ch := cli.Rulesets.Watch(ctx, "a", "")
 		evs := <-ch
 		require.NoError(t, evs.Err)
-		require.EqualValues(t, 4, i)
+		require.EqualValues(t, 4, atomic.LoadInt32(&i))
 	})
 
 	t.Run("WatchRuleset/NotFound", func(t *testing.T) {

--- a/ui/app/.eslintrc.js
+++ b/ui/app/.eslintrc.js
@@ -7,23 +7,20 @@ module.exports = {
     node: true,
     mocha: true,
   },
-  extends: [
-    'plugin:vue/essential',
-    '@vue/airbnb',
-  ],
+  extends: ['plugin:vue/essential', '@vue/airbnb'],
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    "import/extensions": ['error', "ignorePackages"]
+    'import/extensions': ['error', 'ignorePackages'],
+    quotes: ['error', 'single'],
   },
+
   parserOptions: {
     parser: 'babel-eslint',
   },
   settings: {
     'import/resolver': {
-      alias: [
-        ['@', path.join(__dirname, '/src')],
-      ]
-    }
-  }
+      alias: [['@', path.join(__dirname, '/src')]],
+    },
+  },
 };

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@mdi/font": "^3.2.89",
+    "axios": "^0.18.0",
     "es6-promise": "^4.2.5",
-    "isomorphic-fetch": "^2.2.1",
     "roboto-fontface": "^0.10.0",
     "vue": "^2.5.17",
     "vue-router": "^3.0.1",

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@mdi/font": "^3.2.89",
     "axios": "^0.18.0",
+    "brace": "^0.11.1",
     "es6-promise": "^4.2.5",
     "roboto-fontface": "^0.10.0",
     "vue": "^2.5.17",
     "vue-router": "^3.0.1",
+    "vue2-ace-editor": "^0.0.11",
     "vuetify": "^1.3.0"
   },
   "devDependencies": {

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -6,7 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test:unit": "vue-cli-service test:unit --require isomorphic-fetch --require babel-register './src/**/*.spec.js'"
+    "test:unit": "vue-cli-service test:unit --require babel-register './src/**/*.spec.js'"
   },
   "dependencies": {
     "@mdi/font": "^3.2.89",

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -9,11 +9,7 @@
     "test:unit": "vue-cli-service test:unit --require isomorphic-fetch --require babel-register './src/**/*.spec.js'"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.2.0",
-    "@fortawesome/fontawesome-svg-core": "^1.2.6",
-    "@fortawesome/free-brands-svg-icons": "^5.4.1",
-    "@fortawesome/free-solid-svg-icons": "^5.4.1",
-    "@fortawesome/vue-fontawesome": "^0.1.1",
+    "@mdi/font": "^3.2.89",
     "es6-promise": "^4.2.5",
     "isomorphic-fetch": "^2.2.1",
     "roboto-fontface": "^0.10.0",

--- a/ui/app/src/App.vue
+++ b/ui/app/src/App.vue
@@ -3,6 +3,7 @@
     <Navbar />
 
     <v-content>
+      <router-view/>
     </v-content>
   </v-app>
 </template>

--- a/ui/app/src/App.vue
+++ b/ui/app/src/App.vue
@@ -3,7 +3,7 @@
     <Navbar />
 
     <v-content>
-      <router-view/>
+      <router-view />
     </v-content>
   </v-app>
 </template>

--- a/ui/app/src/components/Navbar.vue
+++ b/ui/app/src/components/Navbar.vue
@@ -17,7 +17,7 @@
     >
       <v-toolbar-side-icon @click.stop="drawer = !drawer"></v-toolbar-side-icon>
       <v-toolbar-title class="headline">
-        <span>Regula</span>
+        <router-link to="/">Regula</router-link>
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <v-btn
@@ -58,3 +58,16 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+  .headline {
+    a {
+      text-decoration: none;
+      color: rgba(0,0,0,0.87);
+
+      &:visited {
+        color: rgba(0,0,0,0.87);
+      }
+    }
+  }
+</style>

--- a/ui/app/src/components/Navbar.vue
+++ b/ui/app/src/components/Navbar.vue
@@ -22,29 +22,26 @@
       <v-spacer></v-spacer>
       <v-btn
         flat
+        icon
         href="https://github.com/heetch/regula"
         target="_blank"
       >
-        <fa-icon :icon="['fab', 'github']" size="2x" />
+        <v-icon>mdi-github-circle</v-icon>
       </v-btn>
       <v-btn
         flat
+        icon
         href="https://regula.readthedocs.io/en/latest/"
         target="_blank"
       >
-        <fa-icon :icon="['fas', 'book']" size="2x" />
+        <v-icon>mdi-book-open-outline</v-icon>
       </v-btn>
     </v-toolbar>
   </div>
 </template>
 
 <script>
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
-import { faBook } from '@fortawesome/free-solid-svg-icons';
 import Sidebar from '@/components/Sidebar.vue';
-
-library.add(faGithub, faBook);
 
 export default {
   name: 'Navbar',

--- a/ui/app/src/components/Navbar.vue
+++ b/ui/app/src/components/Navbar.vue
@@ -10,10 +10,10 @@
     </v-navigation-drawer>
 
     <v-toolbar
-        dense
-        fixed
-        clipped-left
-        app
+      dense
+      fixed
+      clipped-left
+      app
     >
       <v-toolbar-side-icon @click.stop="drawer = !drawer"></v-toolbar-side-icon>
       <v-toolbar-title class="headline">
@@ -57,14 +57,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .headline {
-    a {
-      text-decoration: none;
-      color: rgba(0,0,0,0.87);
+.headline {
+  a {
+    text-decoration: none;
+    color: rgba(0, 0, 0, 0.87);
 
-      &:visited {
-        color: rgba(0,0,0,0.87);
-      }
+    &:visited {
+      color: rgba(0, 0, 0, 0.87);
     }
   }
+}
 </style>

--- a/ui/app/src/components/Sidebar.spec.js
+++ b/ui/app/src/components/Sidebar.spec.js
@@ -3,25 +3,37 @@ import { rulesetsToTree } from '@/components/Sidebar.vue';
 
 describe('Sidebar.vue', () => {
   it('builds tree correctly', () => {
-    const items = rulesetsToTree([{ path: 'a/b' }, { path: 'a/c' }, { path: 'a/d/e' }]);
-    expect(items).to.eql([{
-      name: 'a',
-      children: [
-        {
-          name: 'b',
-        },
-        {
-          name: 'c',
-        },
-        {
-          name: 'd',
-          children: [
-            {
-              name: 'e',
-            },
-          ],
-        },
-      ],
-    }]);
+    const items = rulesetsToTree([
+      {
+        path: 'a/b',
+      },
+      {
+        path: 'a/c',
+      },
+      {
+        path: 'a/d/e',
+      },
+    ]);
+    expect(items).to.eql([
+      {
+        name: 'a',
+        children: [
+          {
+            name: 'b',
+          },
+          {
+            name: 'c',
+          },
+          {
+            name: 'd',
+            children: [
+              {
+                name: 'e',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/ui/app/src/components/Sidebar.vue
+++ b/ui/app/src/components/Sidebar.vue
@@ -10,7 +10,7 @@
     </v-treeview>
     <div class="new-ruleset mt-5">
       <router-link to="/rulesets/new">
-        <v-btn fab dark color="indigo">
+        <v-btn fab dark color="primary">
           <v-icon dark>mdi-plus</v-icon>
         </v-btn>
       </router-link>
@@ -77,5 +77,9 @@ export default {
     padding: 1em;
     overflow: auto;
     height: 100%;
+
+    .new-ruleset a {
+      text-decoration: none;
+    }
   }
 </style>

--- a/ui/app/src/components/Sidebar.vue
+++ b/ui/app/src/components/Sidebar.vue
@@ -23,6 +23,8 @@
 </template>
 
 <script>
+import axios from 'axios';
+
 // turns a list of rulesets to a tree compatible with the TreeView component
 export const rulesetsToTree = (rulesets = []) => {
   const tree = {};
@@ -68,9 +70,11 @@ export default {
 
   methods: {
     fetchRulesets() {
-      fetch('/ui/i/rulesets/')
-        .then(stream => stream.json())
-        .then(({ rulesets = [] }) => {
+      axios
+        .get('/ui/i/rulesets/')
+        .then(({ data = {} }) => {
+          const { rulesets = [] } = data;
+
           this.items = rulesetsToTree(rulesets);
         })
         .catch(console.error);

--- a/ui/app/src/components/Sidebar.vue
+++ b/ui/app/src/components/Sidebar.vue
@@ -1,6 +1,5 @@
 <template>
   <div id="sidebar">
-    <h2>Rulesets</h2>
     <v-treeview
       v-model="tree"
       :items="items"
@@ -9,6 +8,13 @@
       open-on-click
     >
     </v-treeview>
+    <div class="new-ruleset mt-5">
+      <router-link to="/rulesets/new">
+        <v-btn fab dark color="indigo">
+          <v-icon dark>mdi-plus</v-icon>
+        </v-btn>
+      </router-link>
+    </div>
   </div>
 </template>
 
@@ -55,7 +61,7 @@ export default {
 
   methods: {
     fetchRulesets() {
-      fetch('i/rulesets/')
+      fetch('/ui/i/rulesets/')
         .then(stream => stream.json())
         .then(({ rulesets = [] }) => {
           this.items = rulesetsToTree(rulesets);
@@ -66,7 +72,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   #sidebar {
     padding: 1em;
     overflow: auto;

--- a/ui/app/src/components/Sidebar.vue
+++ b/ui/app/src/components/Sidebar.vue
@@ -10,7 +10,11 @@
     </v-treeview>
     <div class="new-ruleset mt-5">
       <router-link to="/rulesets/new">
-        <v-btn fab dark color="primary">
+        <v-btn
+          fab
+          dark
+          color="primary"
+        >
           <v-icon dark>mdi-plus</v-icon>
         </v-btn>
       </router-link>
@@ -42,8 +46,11 @@ export const rulesetsToTree = (rulesets = []) => {
 
   // walk is a private function that walks through a given object and returns
   // a tree compatible with the TreeView component
-  const walk = (o = {}) => Object.keys(o)
-    .map(k => ({ name: k, ...(!Array.isArray(o[k]) && { children: walk(o[k]) }) }));
+  const walk = (o = {}) =>
+    Object.keys(o).map(k => ({
+      name: k,
+      ...(!Array.isArray(o[k]) && { children: walk(o[k]) }),
+    }));
 
   return walk(tree);
 };
@@ -73,13 +80,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  #sidebar {
-    padding: 1em;
-    overflow: auto;
-    height: 100%;
+#sidebar {
+  padding: 1em;
+  overflow: auto;
+  height: 100%;
 
-    .new-ruleset a {
-      text-decoration: none;
-    }
+  .new-ruleset a {
+    text-decoration: none;
   }
+}
 </style>

--- a/ui/app/src/main.js
+++ b/ui/app/src/main.js
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import '@mdi/font/css/materialdesignicons.css';
 
 import './plugins/vuetify';
-import './plugins/fetch';
 import App from './App';
 import router from './router';
 

--- a/ui/app/src/main.js
+++ b/ui/app/src/main.js
@@ -1,7 +1,8 @@
 import Vue from 'vue';
+import '@mdi/font/css/materialdesignicons.css';
+
 import './plugins/vuetify';
 import './plugins/fetch';
-import './plugins/font-awesome';
 import App from './App';
 import router from './router';
 

--- a/ui/app/src/main.js
+++ b/ui/app/src/main.js
@@ -3,9 +3,11 @@ import './plugins/vuetify';
 import './plugins/fetch';
 import './plugins/font-awesome';
 import App from './App';
+import router from './router';
 
 Vue.config.productionTip = false;
 
 new Vue({
+  router,
   render: h => h(App),
 }).$mount('#app');

--- a/ui/app/src/plugins/fetch.js
+++ b/ui/app/src/plugins/fetch.js
@@ -1,3 +1,0 @@
-// setup the Fetch API polyfill
-require('es6-promise').polyfill();
-require('isomorphic-fetch');

--- a/ui/app/src/plugins/font-awesome.js
+++ b/ui/app/src/plugins/font-awesome.js
@@ -1,8 +1,0 @@
-import 'roboto-fontface/css/roboto/roboto-fontface.css';
-import '@fortawesome/fontawesome-free/css/all.css';
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-
-import Vue from 'vue';
-
-// Setup Font Awesome icon font library
-Vue.component('fa-icon', FontAwesomeIcon);

--- a/ui/app/src/plugins/vuetify.js
+++ b/ui/app/src/plugins/vuetify.js
@@ -4,5 +4,5 @@ import 'vuetify/src/stylus/app.styl';
 
 Vue.use(Vuetify, {
   customProperties: true,
-  iconfont: 'fa', // select the Font Awesome iconfont for the entire app
+  iconfont: 'mdi', // select the Material Design Icons iconfont for the entire app
 });

--- a/ui/app/src/router.js
+++ b/ui/app/src/router.js
@@ -1,0 +1,25 @@
+import Vue from 'vue';
+import Router from 'vue-router';
+import Home from './views/Home.vue';
+
+Vue.use(Router);
+
+export default new Router({
+  mode: 'history',
+  base: process.env.BASE_URL,
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: Home,
+    },
+    {
+      path: '/rulesets/new',
+      name: 'new-ruleset',
+      // route level code-splitting
+      // this generates a separate chunk (about.[hash].js) for this route
+      // which is lazy-loaded when the route is visited.
+      component: () => import(/* webpackChunkName: "about" */ './views/NewRuleset.vue'),
+    },
+  ],
+});

--- a/ui/app/src/router.js
+++ b/ui/app/src/router.js
@@ -17,9 +17,10 @@ export default new Router({
       path: '/rulesets/new',
       name: 'new-ruleset',
       // route level code-splitting
-      // this generates a separate chunk (about.[hash].js) for this route
+      // this generates a separate chunk (newRuleset.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
-      component: () => import(/* webpackChunkName: "about" */ './views/NewRuleset/NewRuleset.vue'),
+      component: () =>
+        import(/* webpackChunkName: "newRuleset" */ './views/NewRuleset/NewRuleset.vue'),
     },
   ],
 });

--- a/ui/app/src/router.js
+++ b/ui/app/src/router.js
@@ -19,7 +19,7 @@ export default new Router({
       // route level code-splitting
       // this generates a separate chunk (about.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
-      component: () => import(/* webpackChunkName: "about" */ './views/NewRuleset.vue'),
+      component: () => import(/* webpackChunkName: "about" */ './views/NewRuleset/NewRuleset.vue'),
     },
   ],
 });

--- a/ui/app/src/views/Home.vue
+++ b/ui/app/src/views/Home.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="home">
+    <h1>This is a home page</h1>
+  </div>
+</template>

--- a/ui/app/src/views/Home.vue
+++ b/ui/app/src/views/Home.vue
@@ -1,5 +1,4 @@
 <template>
   <div class="home">
-    <h1>This is a home page</h1>
   </div>
 </template>

--- a/ui/app/src/views/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset.vue
@@ -1,5 +1,103 @@
 <template>
-  <div class="new-ruleset">
-    <h1>This is the new ruleset page</h1>
-  </div>
+  <v-container class="new-ruleset ">
+    <h1 class="display-2">New ruleset</h1>
+
+    <v-form>
+
+      <v-card class="mt-3">
+
+        <v-card-title primary-title>
+          <div>
+            <h3 class="title">Signature</h3>
+          </div>
+        </v-card-title>
+
+        <v-card-text>
+          <!-- path -->
+          <v-text-field
+            box
+            :rules="pathRules"
+            label="Path"
+            required
+            hint="Must start with a letter and contain letters,
+              numbers, dashes or slashes. Must not end with a dash or slash."
+          ></v-text-field>
+
+          <!-- parameters  -->
+          <h3 class="subheading mt-3">Parameters</h3>
+          <v-layout row wrap>
+            <v-flex xs12 sm6 class="pr-2">
+              <v-text-field
+                box
+                :rules="paramNameRules"
+                label="Name"
+                required
+                hint="Must start with a letter and contain letters,
+                  numbers or dashes. Must not end with a dash."
+              ></v-text-field>
+            </v-flex>
+            <v-flex xs12 sm6 class="pr-2">
+              <v-select
+                box
+                :items="paramTypes"
+                label="Type"
+              ></v-select>
+            </v-flex>
+          </v-layout>
+          <v-btn small fab color="secondary" class="ma-0 mt-2">
+            <v-icon dark>mdi-plus</v-icon>
+          </v-btn>
+
+          <!-- return type -->
+          <h3 class="subheading mt-4">Return type</h3>
+          <v-select
+            box
+            :items="paramTypes"
+            label="Type"
+          ></v-select>
+
+        </v-card-text>
+
+      </v-card>
+
+      <v-card class="mt-3">
+
+        <v-card-title primary-title>
+          <div>
+            <h3 class="title">Rules</h3>
+          </div>
+        </v-card-title>
+
+        <v-card-text>
+            <!-- parameters  -->
+          <h3 class="subheading mb-3">Rule 1</h3>
+          <v-layout row wrap>
+            <v-flex xs12 sm8 class="pr-2">
+              <v-textarea
+                box
+                label="Code"
+                name="rule-1"
+                value="(#true)"
+              ></v-textarea>
+            </v-flex>
+            <v-flex xs12 sm4 class="pr-2">
+              <v-text-field
+                box
+                :rules="pathRules"
+                label="Result"
+                required
+              ></v-text-field>
+            </v-flex>
+          </v-layout>
+          <v-btn small fab color="secondary" class="ma-0 mt-2">
+            <v-icon dark>mdi-plus</v-icon>
+          </v-btn>
+
+        </v-card-text>
+
+      </v-card>
+
+    </v-form>
+
+  </v-container>
 </template>

--- a/ui/app/src/views/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="new-ruleset">
+    <h1>This is the new ruleset page</h1>
+  </div>
+</template>

--- a/ui/app/src/views/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="new-ruleset ">
-    <h1 class="display-2">New ruleset</h1>
+    <h1 class="display-1">New ruleset</h1>
 
     <v-form>
 
@@ -97,6 +97,15 @@
 
       </v-card>
 
+      <div class="text-xs-right mt-3">
+        <v-btn
+          :disabled="!valid"
+          @click="submit"
+          color="primary"
+        >
+          create new ruleset
+        </v-btn>
+      </div>
     </v-form>
 
   </v-container>

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -6,7 +6,10 @@
 
       <Signature v-model="signature" />
 
-      <Rules v-model="rules" />
+      <Rules
+        v-model="rules"
+        :return-type="signature.returnType"
+      />
 
       <div class="text-xs-right mt-3">
         <v-btn

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -4,7 +4,7 @@
 
     <v-form>
 
-      <Signature />
+      <Signature v-model="signature" />
 
       <Rules />
 
@@ -36,6 +36,11 @@ export default {
 
   data: () => ({
     valid: false,
+    signature: {
+      path: '',
+      returnType: '',
+      params: [{ name: '', type: '' }],
+    },
   }),
 
   methods: {

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -28,9 +28,24 @@ import Rules from './Rules.vue';
 
 export default {
   name: 'NewRuleset',
+
   components: {
     Signature,
     Rules,
+  },
+
+  data: () => ({
+    valid: false,
+  }),
+
+  methods: {
+    submit() {
+      if (this.$refs.form.validate()) {
+        console.log('Valid form');
+      } else {
+        console.log('Invalid form');
+      }
+    },
   },
 };
 </script>

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -46,7 +46,7 @@ export default {
     signature: {
       path: '',
       returnType: '',
-      params: [{ name: '', type: '' }],
+      params: [],
     },
     rules: [{ sExpr: '(#true)', returnValue: '' }],
   }),

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -2,7 +2,10 @@
   <v-container class="new-ruleset ">
     <h1 class="display-1">New ruleset</h1>
 
-    <v-form>
+    <v-form
+      ref="form"
+      v-model="valid"
+    >
 
       <Signature v-model="signature" />
 
@@ -50,7 +53,8 @@ export default {
   methods: {
     submit() {
       if (this.$refs.form.validate()) {
-        console.log('Valid form');
+        console.log(this.signature);
+        console.log(this.rules);
       } else {
         console.log('Invalid form');
       }

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -55,7 +55,7 @@ export default {
     submit() {
       if (this.$refs.form.validate()) {
         axios
-          .put('/i/rulesets', {
+          .put('/ui/i/rulesets', {
             path: this.signature.path,
             signature: {
               params: this.signature.params,
@@ -63,6 +63,7 @@ export default {
             },
             rules: this.rules,
           })
+          // temporary error handling until we implement the backend endpoint
           .then(console.log)
           .catch(console.error);
       } else {

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -4,9 +4,9 @@
 
     <v-form>
 
-      <Signature/>
+      <Signature />
 
-      <Rules/>
+      <Rules />
 
       <div class="text-xs-right mt-3">
         <v-btn

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -1,4 +1,6 @@
+
 <template>
+  <!-- This page displays the form to create a new ruleset -->
   <v-container class="new-ruleset ">
     <h1 class="display-1">New ruleset</h1>
 
@@ -7,12 +9,11 @@
       v-model="valid"
     >
 
-      <Signature v-model="signature" />
+      <!-- delegate path and signature form to Signature component -->
+      <Signature v-model="ruleset" />
 
-      <Rules
-        v-model="rules"
-        :return-type="signature.returnType"
-      />
+      <!-- delegate rules form to Rules component -->
+      <Rules v-model="ruleset" />
 
       <div class="text-xs-right mt-3">
         <v-btn
@@ -30,6 +31,7 @@
 
 <script>
 import axios from 'axios';
+import { Ruleset, Rule } from './ruleset';
 import Signature from './Signature.vue';
 import Rules from './Rules.vue';
 
@@ -43,26 +45,17 @@ export default {
 
   data: () => ({
     valid: false,
-    signature: {
-      path: '',
-      returnType: '',
-      params: [],
-    },
-    rules: [{ sExpr: '(#true)', returnValue: '' }],
+    ruleset: new Ruleset({
+      // start with one rule with default values
+      rules: [new Rule()],
+    }),
   }),
 
   methods: {
     submit() {
       if (this.$refs.form.validate()) {
         axios
-          .put('/ui/i/rulesets', {
-            path: this.signature.path,
-            signature: {
-              params: this.signature.params,
-              returnType: this.signature.returnType,
-            },
-            rules: this.rules,
-          })
+          .put('/ui/i/rulesets', this.ruleset)
           // temporary error handling until we implement the backend endpoint
           .then(console.log)
           .catch(console.error);

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-container class="new-ruleset ">
+    <h1 class="display-1">New ruleset</h1>
+
+    <v-form>
+
+      <Signature/>
+
+      <Rules/>
+
+      <div class="text-xs-right mt-3">
+        <v-btn
+          :disabled="!valid"
+          @click="submit"
+          color="primary"
+        >
+          create new ruleset
+        </v-btn>
+      </div>
+    </v-form>
+
+  </v-container>
+</template>
+
+<script>
+import Signature from './Signature.vue';
+import Rules from './Rules.vue';
+
+export default {
+  name: 'NewRuleset',
+  components: {
+    Signature,
+    Rules,
+  },
+};
+</script>

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -6,7 +6,7 @@
 
       <Signature v-model="signature" />
 
-      <Rules />
+      <Rules v-model="rules" />
 
       <div class="text-xs-right mt-3">
         <v-btn
@@ -41,6 +41,7 @@ export default {
       returnType: '',
       params: [{ name: '', type: '' }],
     },
+    rules: [{ code: '(#true)', result: '' }],
   }),
 
   methods: {

--- a/ui/app/src/views/NewRuleset/NewRuleset.vue
+++ b/ui/app/src/views/NewRuleset/NewRuleset.vue
@@ -29,6 +29,7 @@
 </template>
 
 <script>
+import axios from 'axios';
 import Signature from './Signature.vue';
 import Rules from './Rules.vue';
 
@@ -47,14 +48,23 @@ export default {
       returnType: '',
       params: [{ name: '', type: '' }],
     },
-    rules: [{ code: '(#true)', result: '' }],
+    rules: [{ sExpr: '(#true)', returnValue: '' }],
   }),
 
   methods: {
     submit() {
       if (this.$refs.form.validate()) {
-        console.log(this.signature);
-        console.log(this.rules);
+        axios
+          .put('/i/rulesets', {
+            path: this.signature.path,
+            signature: {
+              params: this.signature.params,
+              returnType: this.signature.returnType,
+            },
+            rules: this.rules,
+          })
+          .then(console.log)
+          .catch(console.error);
       } else {
         console.log('Invalid form');
       }

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -9,7 +9,7 @@
     <v-card-text>
       <!-- parameters  -->
       <div
-        v-for="(rule, index) in rules"
+        v-for="(rule, index) in value"
         :key="index"
       >
         <h3 class="subheading mb-3">Rule {{index + 1}}</h3>
@@ -88,19 +88,20 @@
 export default {
   name: 'Rules',
 
+  props: { value: Array },
+
   data: () => ({
-    rules: [{ code: '(#true)', result: '' }],
     codeRules: [v => !!v || 'Code is required'],
     resultsRules: [v => !!v || 'Result is required'],
   }),
 
   methods: {
     addRule() {
-      this.rules.push({ code: '(#true)', result: '' });
+      this.value.push({ code: '(#true)', result: '' });
     },
 
     removeRule(index) {
-      this.rules.splice(index, 1);
+      this.value.splice(index, 1);
     },
   },
 };

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -1,0 +1,44 @@
+<template>
+    <v-card class="mt-3">
+
+        <v-card-title primary-title>
+          <div>
+            <h3 class="title">Rules</h3>
+          </div>
+        </v-card-title>
+
+        <v-card-text>
+            <!-- parameters  -->
+          <h3 class="subheading mb-3">Rule 1</h3>
+          <v-layout row wrap>
+            <v-flex xs12 sm8 class="pr-2">
+              <v-textarea
+                box
+                label="Code"
+                name="rule-1"
+                value="(#true)"
+              ></v-textarea>
+            </v-flex>
+            <v-flex xs12 sm4 class="pr-2">
+              <v-text-field
+                box
+                :rules="pathRules"
+                label="Result"
+                required
+              ></v-text-field>
+            </v-flex>
+          </v-layout>
+          <v-btn small fab color="secondary" class="ma-0 mt-2">
+            <v-icon dark>mdi-plus</v-icon>
+          </v-btn>
+
+        </v-card-text>
+
+    </v-card>
+</template>
+
+<script>
+export default {
+  name: 'Rules',
+};
+</script>

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -19,7 +19,7 @@
         >
           <v-flex
             xs12
-            sm8
+            sm7
             class="pr-2"
           >
             <v-textarea
@@ -42,6 +42,31 @@
               required
               v-model="rule.result"
             ></v-text-field>
+          </v-flex>
+          <v-flex
+            xs12
+            sm1
+            class="text-sm-center"
+          >
+            <v-btn
+              v-if="index == 0"
+              small
+              fab
+              color="error"
+              disabled
+              @click="removeRule(index)"
+            >
+              <v-icon dark>mdi-minus</v-icon>
+            </v-btn>
+            <v-btn
+              v-if="index > 0"
+              small
+              fab
+              color="error"
+              @click="removeRule(index)"
+            >
+              <v-icon dark>mdi-minus</v-icon>
+            </v-btn>
           </v-flex>
         </v-layout>
       </div>

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -1,44 +1,82 @@
 <template>
-    <v-card class="mt-3">
+  <v-card class="mt-3">
+    <v-card-title primary-title>
+      <div>
+        <h3 class="title">Rules</h3>
+      </div>
+    </v-card-title>
 
-        <v-card-title primary-title>
-          <div>
-            <h3 class="title">Rules</h3>
-          </div>
-        </v-card-title>
-
-        <v-card-text>
-            <!-- parameters  -->
-          <h3 class="subheading mb-3">Rule 1</h3>
-          <v-layout row wrap>
-            <v-flex xs12 sm8 class="pr-2">
-              <v-textarea
-                box
-                label="Code"
-                name="rule-1"
-                value="(#true)"
-              ></v-textarea>
-            </v-flex>
-            <v-flex xs12 sm4 class="pr-2">
-              <v-text-field
-                box
-                :rules="pathRules"
-                label="Result"
-                required
-              ></v-text-field>
-            </v-flex>
-          </v-layout>
-          <v-btn small fab color="secondary" class="ma-0 mt-2">
-            <v-icon dark>mdi-plus</v-icon>
-          </v-btn>
-
-        </v-card-text>
-
-    </v-card>
+    <v-card-text>
+      <!-- parameters  -->
+      <div
+        v-for="(rule, index) in rules"
+        :key="index"
+      >
+        <h3 class="subheading mb-3">Rule {{index + 1}}</h3>
+        <v-layout
+          row
+          wrap
+        >
+          <v-flex
+            xs12
+            sm8
+            class="pr-2"
+          >
+            <v-textarea
+              box
+              label="Code"
+              :name="'rule-' + (index+1)"
+              :rules="codeRules"
+              v-model="rule.code"
+            ></v-textarea>
+          </v-flex>
+          <v-flex
+            xs12
+            sm4
+            class="pr-2"
+          >
+            <v-text-field
+              box
+              :rules="resultsRules"
+              label="Result"
+              required
+              v-model="rule.result"
+            ></v-text-field>
+          </v-flex>
+        </v-layout>
+      </div>
+      <v-btn
+        small
+        fab
+        color="secondary"
+        class="ma-0 mt-2"
+        @click="addRule"
+      >
+        <v-icon dark>mdi-plus</v-icon>
+      </v-btn>
+    </v-card-text>
+  </v-card>
 </template>
+
 
 <script>
 export default {
   name: 'Rules',
+
+  data: () => ({
+    rules: [{ code: '(#true)', result: '' }],
+    codeRules: [v => !!v || 'Code is required'],
+    resultsRules: [v => !!v || 'Result is required'],
+  }),
+
+  methods: {
+    addRule() {
+      this.rules.push({ code: '(#true)', result: '' });
+    },
+
+    removeRule(index) {
+      this.rules.splice(index, 1);
+    },
+  },
 };
 </script>

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -37,7 +37,7 @@
           >
             <v-text-field
               box
-              v-if="returnType != 'Json'"
+              v-if="returnType !== 'Json'"
               :rules="resultsRules"
               :type="returnTypeInputType"
               label="Result"
@@ -46,7 +46,7 @@
             ></v-text-field>
             <v-textarea
               box
-              v-if="returnType == 'Json'"
+              v-if="returnType === 'Json'"
               :rules="resultsRules"
               label="Result"
               required
@@ -108,10 +108,9 @@ export default {
   }),
 
   computed: {
+    // select the right input type based on the selected ruleset return type
     returnTypeInputType() {
       switch (this.returnType) {
-        case 'String':
-          return 'text';
         case 'Int64':
           return 'number';
         case 'Float64':

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -40,7 +40,7 @@
           >
             <v-text-field
               box
-              v-if="returnType !== 'Json'"
+              v-if="returnType !== 'JSON'"
               :rules="resultsRules"
               :type="returnTypeInputType"
               label="Result"
@@ -49,7 +49,7 @@
             ></v-text-field>
             <v-textarea
               box
-              v-if="returnType === 'Json'"
+              v-if="returnType === 'JSON'"
               :rules="resultsRules"
               label="Result"
               required

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -37,11 +37,21 @@
           >
             <v-text-field
               box
+              v-if="returnType != 'Json'"
               :rules="resultsRules"
+              :type="returnTypeInputType"
               label="Result"
               required
               v-model="rule.result"
             ></v-text-field>
+            <v-textarea
+              box
+              v-if="returnType == 'Json'"
+              :rules="resultsRules"
+              label="Result"
+              required
+              v-model="rule.result"
+            ></v-textarea>
           </v-flex>
           <v-flex
             xs12
@@ -54,7 +64,6 @@
               fab
               color="error"
               disabled
-              @click="removeRule(index)"
             >
               <v-icon dark>mdi-minus</v-icon>
             </v-btn>
@@ -88,12 +97,30 @@
 export default {
   name: 'Rules',
 
-  props: { value: Array },
+  props: {
+    value: Array,
+    returnType: String,
+  },
 
   data: () => ({
     codeRules: [v => !!v || 'Code is required'],
     resultsRules: [v => !!v || 'Result is required'],
   }),
+
+  computed: {
+    returnTypeInputType() {
+      switch (this.returnType) {
+        case 'String':
+          return 'text';
+        case 'Int64':
+          return 'number';
+        case 'Float64':
+          return 'number';
+        default:
+          return 'text';
+      }
+    },
+  },
 
   methods: {
     addRule() {

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- This component handles the form for the rules.-->
   <v-card class="mt-3">
     <v-card-title primary-title>
       <div>
@@ -7,9 +8,9 @@
     </v-card-title>
 
     <v-card-text>
-      <!-- parameters  -->
+      <!-- rules  -->
       <div
-        v-for="(rule, index) in value"
+        v-for="(rule, index) in value.rules"
         :key="index"
       >
         <h3 class="subheading mb-3">Rule {{index + 1}}</h3>
@@ -24,7 +25,6 @@
           >
             <editor
               v-model="rule.sExpr"
-              @init="editorInit"
               lang="lisp"
               theme="tomorrow"
               width="100%"
@@ -40,7 +40,7 @@
           >
             <v-text-field
               box
-              v-if="returnType !== 'JSON'"
+              v-if="value.signature.returnType !== 'JSON'"
               :rules="resultsRules"
               :type="returnTypeInputType"
               label="Result"
@@ -49,7 +49,7 @@
             ></v-text-field>
             <v-textarea
               box
-              v-if="returnType === 'JSON'"
+              v-if="value.signature.returnType === 'JSON'"
               :rules="resultsRules"
               label="Result"
               required
@@ -98,18 +98,22 @@
 
 <script>
 import editor from 'vue2-ace-editor';
+import 'brace/ext/language_tools';
+import 'brace/mode/lisp';
+import 'brace/theme/tomorrow';
+import { Ruleset, Rule } from './ruleset';
 
 export default {
   name: 'Rules',
 
   props: {
-    value: Array,
-    returnType: String,
+    value: Ruleset,
   },
 
   data: () => ({
     codeRules: [v => !!v || 'Code is required'],
     resultsRules: [v => !!v || 'Result is required'],
+    // editor customization
     editorOptions: {
       showGutter: false,
       showLineNumbers: false,
@@ -121,7 +125,7 @@ export default {
   computed: {
     // select the right input type based on the selected ruleset return type
     returnTypeInputType() {
-      switch (this.returnType) {
+      switch (this.value.signature.returnType) {
         case 'Int64':
           return 'number';
         case 'Float64':
@@ -137,18 +141,12 @@ export default {
   },
 
   methods: {
-    editorInit() {
-      require('brace/ext/language_tools');
-      require('brace/mode/lisp');
-      require('brace/theme/tomorrow');
-    },
-
     addRule() {
-      this.value.push({ sExpr: '(#true)', returnValue: '' });
+      this.value.rules.push(new Rule());
     },
 
     removeRule(index) {
-      this.value.splice(index, 1);
+      this.value.rules.splice(index, 1);
     },
   },
 };

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -111,7 +111,9 @@ export default {
   },
 
   data: () => ({
+    // validation rules for S-Expressions. Only check if they're not empty.
     codeRules: [v => !!v || 'Code is required'],
+    // validation rules for return values. Only check if thery're not empty.
     resultsRules: [v => !!v || 'Result is required'],
     // editor customization
     editorOptions: {
@@ -123,7 +125,7 @@ export default {
   }),
 
   computed: {
-    // select the right input type based on the selected ruleset return type
+    // select the right input type based on the selected ruleset return type. JSON is handled separately in the component html.
     returnTypeInputType() {
       switch (this.value.signature.returnType) {
         case 'Int64':
@@ -141,10 +143,12 @@ export default {
   },
 
   methods: {
+    // add a new rule to the ruleset when a user clicks on the + button.
     addRule() {
       this.value.rules.push(new Rule());
     },
 
+    // remove the selected ruleset from the ruleset when a user clicks on the - button.
     removeRule(index) {
       this.value.rules.splice(index, 1);
     },

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -22,13 +22,16 @@
             sm7
             class="pr-2"
           >
-            <v-textarea
-              box
-              label="Code"
-              :name="'rule-' + (index+1)"
-              :rules="codeRules"
+            <editor
               v-model="rule.sExpr"
-            ></v-textarea>
+              @init="editorInit"
+              lang="lisp"
+              theme="tomorrow"
+              width="100%"
+              height="100"
+              :options="editorOptions"
+            >
+            </editor>
           </v-flex>
           <v-flex
             xs12
@@ -50,7 +53,7 @@
               :rules="resultsRules"
               label="Result"
               required
-              v-model="rule.result"
+              v-model="rule.returnValue"
             ></v-textarea>
           </v-flex>
           <v-flex
@@ -94,6 +97,8 @@
 
 
 <script>
+import editor from 'vue2-ace-editor';
+
 export default {
   name: 'Rules',
 
@@ -105,6 +110,12 @@ export default {
   data: () => ({
     codeRules: [v => !!v || 'Code is required'],
     resultsRules: [v => !!v || 'Result is required'],
+    editorOptions: {
+      showGutter: false,
+      showLineNumbers: false,
+      highlightActiveLine: false,
+      fontSize: '1.5em',
+    },
   }),
 
   computed: {
@@ -121,9 +132,19 @@ export default {
     },
   },
 
+  components: {
+    editor,
+  },
+
   methods: {
+    editorInit() {
+      require('brace/ext/language_tools');
+      require('brace/mode/lisp');
+      require('brace/theme/tomorrow');
+    },
+
     addRule() {
-      this.value.push({ code: '(#true)', result: '' });
+      this.value.push({ sExpr: '(#true)', returnValue: '' });
     },
 
     removeRule(index) {

--- a/ui/app/src/views/NewRuleset/Rules.vue
+++ b/ui/app/src/views/NewRuleset/Rules.vue
@@ -27,7 +27,7 @@
               label="Code"
               :name="'rule-' + (index+1)"
               :rules="codeRules"
-              v-model="rule.code"
+              v-model="rule.sExpr"
             ></v-textarea>
           </v-flex>
           <v-flex
@@ -42,7 +42,7 @@
               :type="returnTypeInputType"
               label="Result"
               required
-              v-model="rule.result"
+              v-model="rule.returnValue"
             ></v-text-field>
             <v-textarea
               box

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -21,8 +21,17 @@
       <!-- parameters  -->
       <h3 class="subheading mt-3">Parameters</h3>
 
-      <v-layout row wrap v-for="(param, index) in params" :key="index">
-        <v-flex xs12 sm6 class="pr-2">
+      <v-layout
+        row
+        wrap
+        v-for="(param, index) in params"
+        :key="index"
+      >
+        <v-flex
+          xs12
+          sm6
+          class="pr-2"
+        >
           <v-text-field
             box
             :rules="paramNameRules"
@@ -34,35 +43,67 @@
           ></v-text-field>
         </v-flex>
 
-        <v-flex xs12 sm6 class="pr-2">
-          <v-select box :items="paramTypes" label="Type" v-model="param.type">
-            <v-btn
-              v-if="index > 0"
-              slot="append-outer"
-              style="top: -16px"
-              small
-              fab
-              color="error"
-              @click="removeParam(index)"
-            >
-              <v-icon dark>mdi-minus</v-icon>
-            </v-btn>
-          </v-select>
+        <v-flex
+          xs12
+          sm5
+          class="pr-2"
+        >
+          <v-select
+            box
+            :items="paramTypes"
+            label="Type"
+            v-model="param.type"
+          ></v-select>
         </v-flex>
 
-        <v-flex xs12 sm1 class="text-sm-center"></v-flex>
+        <v-flex
+          xs12
+          sm1
+          class="text-sm-center"
+        >
+          <v-btn
+            v-if="index == 0"
+            small
+            fab
+            color="error"
+            disabled
+            @click="removeParam(index)"
+          >
+            <v-icon dark>mdi-minus</v-icon>
+          </v-btn>
+          <v-btn
+            v-if="index > 0"
+            small
+            fab
+            color="error"
+            @click="removeParam(index)"
+          >
+            <v-icon dark>mdi-minus</v-icon>
+          </v-btn>
+        </v-flex>
       </v-layout>
 
-      <v-btn small fab color="secondary" class="ma-0 mt-2" @click="addParam">
+      <v-btn
+        small
+        fab
+        color="secondary"
+        class="ma-0 mt-2"
+        @click="addParam"
+      >
         <v-icon dark>mdi-plus</v-icon>
       </v-btn>
 
       <!-- return type -->
       <h3 class="subheading mt-4">Return type</h3>
-      <v-select box :items="returnTypes" label="Type"></v-select>
+      <v-select
+        box
+        :items="returnTypes"
+        label="Type"
+      ></v-select>
     </v-card-text>
   </v-card>
 </template>
+
 
 <script>
 export default {

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -10,7 +10,7 @@
       <!-- path -->
       <v-text-field
         box
-        v-model="path"
+        v-model="value.path"
         :rules="pathRules"
         label="Path"
         required
@@ -24,7 +24,7 @@
       <v-layout
         row
         wrap
-        v-for="(param, index) in params"
+        v-for="(param, index) in value.params"
         :key="index"
       >
         <v-flex
@@ -99,6 +99,7 @@
         box
         :items="returnTypes"
         label="Type"
+        v-model="value.returnType"
       ></v-select>
     </v-card-text>
   </v-card>
@@ -108,14 +109,13 @@
 <script>
 export default {
   name: 'Signature',
+  props: ['value'],
 
   data: () => ({
-    path: '',
     pathRules: [
       v => !!v || 'Path is required',
       v => /^[a-z]+(?:[a-z0-9-/]?[a-z0-9])*$/.test(v) || 'Path must be valid',
     ],
-    params: [{ name: '', type: '' }],
     paramNameRules: [
       v => !!v || 'Param name is required',
       v =>
@@ -127,11 +127,11 @@ export default {
 
   methods: {
     addParam() {
-      this.params.push({ name: '', type: '' });
+      this.value.params.push({ name: '', type: '' });
     },
 
     removeParam(index) {
-      this.params.splice(index, 1);
+      this.value.params.splice(index, 1);
     },
   },
 };

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -25,7 +25,7 @@
       <v-layout
         row
         wrap
-        v-for="(param, index) in value.params"
+        v-for="(param, index) in value.signature.params"
         :key="index"
       >
         <v-flex
@@ -67,7 +67,8 @@
               slot="item"
               slot-scope="{ item, index }"
             >
-              <span>{{ item.value }} </span><span class="grey--text caption">&nbsp;&nbsp;(e.g. {{ item.hint }})</span>
+              <span>{{ item.value }} </span>
+              <span class="grey--text caption">&nbsp;&nbsp;(e.g. {{ item.hint }})</span>
             </template>
           </v-select>
         </v-flex>
@@ -104,7 +105,7 @@
         box
         :items="returnTypes"
         label="Type"
-        v-model="value.returnType"
+        v-model="value.signature.returnType"
         item-text="text"
         item-value="value"
       >
@@ -118,7 +119,8 @@
           slot="item"
           slot-scope="{ item, index }"
         >
-          <span>{{ item.value }} </span><span class="grey--text caption">&nbsp;&nbsp;(e.g. {{ item.hint }})</span>
+          <span>{{ item.value }} </span>
+          <span class="grey--text caption">&nbsp;&nbsp;(e.g. {{ item.hint }})</span>
         </template>
       </v-select>
     </v-card-text>
@@ -127,9 +129,11 @@
 
 
 <script>
+import { Ruleset, Param } from './ruleset';
+
 export default {
   name: 'Signature',
-  props: { value: Object },
+  props: { value: Ruleset },
 
   data: () => ({
     // validation rules for the Path input. Match the API server regex
@@ -163,12 +167,12 @@ export default {
   methods: {
     // adds a param to the list when the user clicks on the + button.
     addParam() {
-      this.value.params.push({ name: '', type: '' });
+      this.value.signature.params.push(new Param());
     },
 
     // removes a param from the list when the user clicks on the - button.
     removeParam(index) {
-      this.value.params.splice(index, 1);
+      this.value.signature.params.splice(index, 1);
     },
   },
 };

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -109,7 +109,7 @@
 <script>
 export default {
   name: 'Signature',
-  props: ['value'],
+  props: { value: Object },
 
   data: () => ({
     pathRules: [

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -1,10 +1,5 @@
 <template>
-  <v-container class="new-ruleset ">
-    <h1 class="display-1">New ruleset</h1>
-
-    <v-form>
-
-      <v-card class="mt-3">
+    <v-card class="mt-3">
 
         <v-card-title primary-title>
           <div>
@@ -59,54 +54,11 @@
         </v-card-text>
 
       </v-card>
-
-      <v-card class="mt-3">
-
-        <v-card-title primary-title>
-          <div>
-            <h3 class="title">Rules</h3>
-          </div>
-        </v-card-title>
-
-        <v-card-text>
-            <!-- parameters  -->
-          <h3 class="subheading mb-3">Rule 1</h3>
-          <v-layout row wrap>
-            <v-flex xs12 sm8 class="pr-2">
-              <v-textarea
-                box
-                label="Code"
-                name="rule-1"
-                value="(#true)"
-              ></v-textarea>
-            </v-flex>
-            <v-flex xs12 sm4 class="pr-2">
-              <v-text-field
-                box
-                :rules="pathRules"
-                label="Result"
-                required
-              ></v-text-field>
-            </v-flex>
-          </v-layout>
-          <v-btn small fab color="secondary" class="ma-0 mt-2">
-            <v-icon dark>mdi-plus</v-icon>
-          </v-btn>
-
-        </v-card-text>
-
-      </v-card>
-
-      <div class="text-xs-right mt-3">
-        <v-btn
-          :disabled="!valid"
-          @click="submit"
-          color="primary"
-        >
-          create new ruleset
-        </v-btn>
-      </div>
-    </v-form>
-
-  </v-container>
 </template>
+
+<script>
+export default {
+  name: 'Signature',
+};
+</script>
+

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -1,69 +1,67 @@
 <template>
-    <v-card class="mt-3">
+  <v-card class="mt-3">
+    <v-card-title primary-title>
+      <div>
+        <h3 class="title">Signature</h3>
+      </div>
+    </v-card-title>
 
-        <v-card-title primary-title>
-          <div>
-            <h3 class="title">Signature</h3>
-          </div>
-        </v-card-title>
-
-        <v-card-text>
-            <!-- path -->
-            <v-text-field
-                box
-                v-model="path"
-                :rules="pathRules"
-                label="Path"
-                required
-                hint="Must start with a letter and may contain letters,
+    <v-card-text>
+      <!-- path -->
+      <v-text-field
+        box
+        v-model="path"
+        :rules="pathRules"
+        label="Path"
+        required
+        hint="Must start with a letter and may contain letters,
                 numbers, dashes or slashes. Must not end with a dash or slash."
-            ></v-text-field>
+      ></v-text-field>
 
-          <!-- parameters  -->
-          <h3 class="subheading mt-3">Parameters</h3>
+      <!-- parameters  -->
+      <h3 class="subheading mt-3">Parameters</h3>
 
-          <v-layout row wrap v-for="(param, index) in params" :key="index">
-            <v-flex xs12 sm6 class="pr-2">
-              <v-text-field
-                box
-                :rules="paramNameRules"
-                label="Name"
-                v-model="param.name"
-                required
-                hint="Must start with a letter and may contain letters,
-                  numbers or dashes. Must not end with a dash."
-              ></v-text-field>
-            </v-flex>
-            <v-flex xs12 sm6 class="pr-2">
-              <v-select
-                box
-                :items="paramTypes"
-                label="Type"
-                v-model="param.type"
-              ></v-select>
-            </v-flex>
-          </v-layout>
-          <v-btn
-            small
-            fab
-            color="secondary"
-            class="ma-0 mt-2"
-            @click="addParam"
-            >
-            <v-icon dark>mdi-plus</v-icon>
-          </v-btn>
-
-          <!-- return type -->
-          <h3 class="subheading mt-4">Return type</h3>
-          <v-select
+      <v-layout row wrap v-for="(param, index) in params" :key="index">
+        <v-flex xs12 sm6 class="pr-2">
+          <v-text-field
             box
-            :items="returnTypes"
-            label="Type"
-          ></v-select>
+            :rules="paramNameRules"
+            label="Name"
+            v-model="param.name"
+            required
+            hint="Must start with a letter and may contain letters,
+                  numbers or dashes. Must not end with a dash."
+          ></v-text-field>
+        </v-flex>
 
-        </v-card-text>
+        <v-flex xs12 sm6 class="pr-2">
+          <v-select box :items="paramTypes" label="Type" v-model="param.type">
+            <v-btn
+              v-if="index > 0"
+              slot="append-outer"
+              style="top: -16px"
+              small
+              fab
+              color="error"
+              @click="removeParam(index)"
+            >
+              <v-icon dark>mdi-minus</v-icon>
+            </v-btn>
+          </v-select>
+        </v-flex>
 
-      </v-card>
+        <v-flex xs12 sm1 class="text-sm-center"></v-flex>
+      </v-layout>
+
+      <v-btn small fab color="secondary" class="ma-0 mt-2" @click="addParam">
+        <v-icon dark>mdi-plus</v-icon>
+      </v-btn>
+
+      <!-- return type -->
+      <h3 class="subheading mt-4">Return type</h3>
+      <v-select box :items="returnTypes" label="Type"></v-select>
+    </v-card-text>
+  </v-card>
 </template>
 
 <script>
@@ -76,31 +74,23 @@ export default {
       v => !!v || 'Path is required',
       v => /^[a-z]+(?:[a-z0-9-/]?[a-z0-9])*$/.test(v) || 'Path must be valid',
     ],
-    params: [
-      { name: '', type: '' },
-    ],
+    params: [{ name: '', type: '' }],
     paramNameRules: [
       v => !!v || 'Param name is required',
-      v => /^[a-z]+(?:[a-z0-9-]?[a-z0-9])*$/.test(v) || 'Param name must be valid',
+      v =>
+        /^[a-z]+(?:[a-z0-9-]?[a-z0-9])*$/.test(v) || 'Param name must be valid',
     ],
-    paramTypes: [
-      'Int64',
-      'Float64',
-      'Bool',
-      'String',
-    ],
-    returnTypes: [
-      'Int64',
-      'Float64',
-      'Bool',
-      'String',
-      'Json',
-    ],
+    paramTypes: ['Int64', 'Float64', 'Bool', 'String'],
+    returnTypes: ['Int64', 'Float64', 'Bool', 'String', 'Json'],
   }),
 
   methods: {
     addParam() {
-      this.params = [...this.params, { name: '', type: '' }];
+      this.params.push({ name: '', type: '' });
+    },
+
+    removeParam(index) {
+      this.params.splice(index, 1);
     },
   },
 };

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -77,17 +77,6 @@
           class="text-sm-center"
         >
           <v-btn
-            v-if="index == 0"
-            small
-            fab
-            color="error"
-            disabled
-            @click="removeParam(index)"
-          >
-            <v-icon dark>mdi-minus</v-icon>
-          </v-btn>
-          <v-btn
-            v-if="index > 0"
             small
             fab
             color="error"

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -53,7 +53,22 @@
             :items="paramTypes"
             label="Type"
             v-model="param.type"
-          ></v-select>
+            item-text="text"
+            item-value="value"
+          >
+            <template
+              slot="selection"
+              slot-scope="{ item, index }"
+            >
+              <span>{{ item.value }}</span>
+            </template>
+            <template
+              slot="item"
+              slot-scope="{ item, index }"
+            >
+              <span>{{ item.value }} </span><span class="grey--text caption">&nbsp;&nbsp;(e.g. {{ item.hint }})</span>
+            </template>
+          </v-select>
         </v-flex>
 
         <v-flex
@@ -100,7 +115,22 @@
         :items="returnTypes"
         label="Type"
         v-model="value.returnType"
-      ></v-select>
+        item-text="text"
+        item-value="value"
+      >
+        <template
+          slot="selection"
+          slot-scope="{ item, index }"
+        >
+          <span>{{ item.value }}</span>
+        </template>
+        <template
+          slot="item"
+          slot-scope="{ item, index }"
+        >
+          <span>{{ item.value }} </span><span class="grey--text caption">&nbsp;&nbsp;(e.g. {{ item.hint }})</span>
+        </template>
+      </v-select>
     </v-card-text>
   </v-card>
 </template>
@@ -121,8 +151,19 @@ export default {
       v =>
         /^[a-z]+(?:[a-z0-9-]?[a-z0-9])*$/.test(v) || 'Param name must be valid',
     ],
-    paramTypes: ['Int64', 'Float64', 'Bool', 'String'],
-    returnTypes: ['Int64', 'Float64', 'Bool', 'String', 'Json'],
+    paramTypes: [
+      { value: 'Int64', hint: '123' },
+      { value: 'Float64', hint: '123.45' },
+      { value: 'Bool', hint: 'true' },
+      { value: 'String', hint: 'foobar' },
+    ],
+    returnTypes: [
+      { value: 'Int64', hint: '123' },
+      { value: 'Float64', hint: '123.45' },
+      { value: 'Bool', hint: 'true' },
+      { value: 'String', hint: 'foobar' },
+      { value: 'JSON', hint: '{"foo": "bar"}' },
+    ],
   }),
 
   methods: {

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- This component handles the form for the path and signature. -->
   <v-card class="mt-3">
     <v-card-title primary-title>
       <div>
@@ -131,21 +132,25 @@ export default {
   props: { value: Object },
 
   data: () => ({
+    // validation rules for the Path input. Match the API server regex
     pathRules: [
       v => !!v || 'Path is required',
       v => /^[a-z]+(?:[a-z0-9-/]?[a-z0-9])*$/.test(v) || 'Path must be valid',
     ],
+    // validation rules for the param names. Match the API server regex
     paramNameRules: [
       v => !!v || 'Param name is required',
       v =>
         /^[a-z]+(?:[a-z0-9-]?[a-z0-9])*$/.test(v) || 'Param name must be valid',
     ],
+    // List of allowed parameter types
     paramTypes: [
       { value: 'Int64', hint: '123' },
       { value: 'Float64', hint: '123.45' },
       { value: 'Bool', hint: 'true' },
       { value: 'String', hint: 'foobar' },
     ],
+    // List of allowed return types
     returnTypes: [
       { value: 'Int64', hint: '123' },
       { value: 'Float64', hint: '123.45' },
@@ -156,10 +161,12 @@ export default {
   }),
 
   methods: {
+    // adds a param to the list when the user clicks on the + button.
     addParam() {
       this.value.params.push({ name: '', type: '' });
     },
 
+    // removes a param from the list when the user clicks on the - button.
     removeParam(index) {
       this.value.params.splice(index, 1);
     },

--- a/ui/app/src/views/NewRuleset/Signature.vue
+++ b/ui/app/src/views/NewRuleset/Signature.vue
@@ -8,26 +8,29 @@
         </v-card-title>
 
         <v-card-text>
-          <!-- path -->
-          <v-text-field
-            box
-            :rules="pathRules"
-            label="Path"
-            required
-            hint="Must start with a letter and contain letters,
-              numbers, dashes or slashes. Must not end with a dash or slash."
-          ></v-text-field>
+            <!-- path -->
+            <v-text-field
+                box
+                v-model="path"
+                :rules="pathRules"
+                label="Path"
+                required
+                hint="Must start with a letter and may contain letters,
+                numbers, dashes or slashes. Must not end with a dash or slash."
+            ></v-text-field>
 
           <!-- parameters  -->
           <h3 class="subheading mt-3">Parameters</h3>
-          <v-layout row wrap>
+
+          <v-layout row wrap v-for="(param, index) in params" :key="index">
             <v-flex xs12 sm6 class="pr-2">
               <v-text-field
                 box
                 :rules="paramNameRules"
                 label="Name"
+                v-model="param.name"
                 required
-                hint="Must start with a letter and contain letters,
+                hint="Must start with a letter and may contain letters,
                   numbers or dashes. Must not end with a dash."
               ></v-text-field>
             </v-flex>
@@ -36,10 +39,17 @@
                 box
                 :items="paramTypes"
                 label="Type"
+                v-model="param.type"
               ></v-select>
             </v-flex>
           </v-layout>
-          <v-btn small fab color="secondary" class="ma-0 mt-2">
+          <v-btn
+            small
+            fab
+            color="secondary"
+            class="ma-0 mt-2"
+            @click="addParam"
+            >
             <v-icon dark>mdi-plus</v-icon>
           </v-btn>
 
@@ -47,7 +57,7 @@
           <h3 class="subheading mt-4">Return type</h3>
           <v-select
             box
-            :items="paramTypes"
+            :items="returnTypes"
             label="Type"
           ></v-select>
 
@@ -59,6 +69,40 @@
 <script>
 export default {
   name: 'Signature',
+
+  data: () => ({
+    path: '',
+    pathRules: [
+      v => !!v || 'Path is required',
+      v => /^[a-z]+(?:[a-z0-9-/]?[a-z0-9])*$/.test(v) || 'Path must be valid',
+    ],
+    params: [
+      { name: '', type: '' },
+    ],
+    paramNameRules: [
+      v => !!v || 'Param name is required',
+      v => /^[a-z]+(?:[a-z0-9-]?[a-z0-9])*$/.test(v) || 'Param name must be valid',
+    ],
+    paramTypes: [
+      'Int64',
+      'Float64',
+      'Bool',
+      'String',
+    ],
+    returnTypes: [
+      'Int64',
+      'Float64',
+      'Bool',
+      'String',
+      'Json',
+    ],
+  }),
+
+  methods: {
+    addParam() {
+      this.params = [...this.params, { name: '', type: '' }];
+    },
+  },
 };
 </script>
 

--- a/ui/app/src/views/NewRuleset/ruleset.js
+++ b/ui/app/src/views/NewRuleset/ruleset.js
@@ -1,0 +1,37 @@
+const defaultRule = '(#true)';
+
+// Describes rule S-Expression and return value.
+class Rule {
+  constructor(sExpr = defaultRule, returnValue = '') {
+    this.sExpr = sExpr;
+    this.returnValue = returnValue;
+  }
+}
+
+// Describes a ruleset parameter.
+class Param {
+  constructor(name = '', type = '') {
+    this.name = name;
+    this.type = type;
+  }
+}
+
+// Describes a ruleset signature.
+class Signature {
+  constructor(returnType = '', params = []) {
+    this.returnType = returnType;
+    this.params = params;
+  }
+}
+
+// Describes the ruleset payload sent to the server when creating a ruleset.
+class Ruleset {
+  constructor({ path = '', signature = new Signature(), rules = [] }) {
+    this.path = path;
+    this.signature = signature;
+    this.rules = rules;
+  }
+}
+
+export { Signature, Param, Ruleset, Rule };
+

--- a/ui/app/vue.config.js
+++ b/ui/app/vue.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   // serve static files from a relative url
-  baseUrl: './',
+  baseUrl: '/ui',
   // proxy any unknown requests (requests that did not match a static file)
   devServer: {
-    proxy: 'http://localhost:5331/ui',
+    proxy: 'http://localhost:5331/',
   },
 };

--- a/ui/app/yarn.lock
+++ b/ui/app/yarn.lock
@@ -713,42 +713,6 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.6.tgz#3f26b9d1bf2d057dfe0f448fe4a2c372508e97f0"
-  integrity sha512-AoBpRaR7IVaXgF2rh0G6cY+WSQhGqDf+JheJMGoSH0E0YjVIUxwha7Nf0SuwQuSQe1GwxZbuaoPUTXA74cRS3w==
-
-"@fortawesome/fontawesome-free@^5.2.0":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.4.1.tgz#6194786c1a705ab84253e06429834466670e3c3f"
-  integrity sha512-ZcxfUmLFl4RLG71cPeZcTXRa6rt3xLnMmomAb7aYKRzUmlRRj7E8EVqSwYSXBiV2x6XpSQmGOQmNQx6HSeSwVQ==
-
-"@fortawesome/fontawesome-svg-core@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.6.tgz#6314da68ff1018633a861ae9fe59e006c4f759a9"
-  integrity sha512-784NAqscnUuMZmf7eNSOn2L71VecLQAkEhfyYzTYnh6i+ycxy7tvpw4Ys4wc6RiglKqTddWRkWBZZ9uGAtfoWg==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.6"
-
-"@fortawesome/free-brands-svg-icons@^5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.4.1.tgz#7c68f7baff4764a8e38e62892372c4b85c70db79"
-  integrity sha512-kt81EOduizFQ8YHURrN1vl230Z8eOu05QysTtZejyJBrMrU1YSDUMNwlP5t8vYZ8VErWx5C1Kqom5OEctDKmrA==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.6"
-
-"@fortawesome/free-solid-svg-icons@^5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.4.1.tgz#9aa1a07176a16886aa176fc0c9d809ab1697fd47"
-  integrity sha512-GRYr+T0sAnfjImhDJt6Gko3sW554+/fEUHgDFJonEEFYLbfLyv6Qn5i/VB8nXcJJLgqHbVwIvwH5Ol3IehIjow==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.6"
-
-"@fortawesome/vue-fontawesome@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.1.tgz#f54cad4028213a011c6ecb10eaf2b99dbd4a8496"
-  integrity sha512-dvPpA9eI18bWr3E+c0JvCYD6xl/keEj0ICTMShUPbxsGkd6PdFU9xYjqA8qE8ahsY+xhbQzZt/k1FKlpMGaRXA==
-
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz#be7c7846128b88f6a9b1d1261a0ad06eb5c0fdf8"
@@ -757,6 +721,11 @@
     cssnano "^4.0.0"
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
+
+"@mdi/font@^3.2.89":
+  version "3.2.89"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-3.2.89.tgz#91790717881c8839729286e516436e7b9f3d96ea"
+  integrity sha512-K+E44jDkv7jwJbRYctw5+k+jE0j43dCN9KH3ZsIcqYjmhQ3ZN3/eBM2oXtFhxSOKYpEn/xFStS+SGRZjlJY/dg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/ui/app/yarn.lock
+++ b/ui/app/yarn.lock
@@ -1749,6 +1749,11 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace@^0.11.0, brace@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
+  integrity sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg=
+
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
@@ -8715,6 +8720,13 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
   integrity sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==
+
+vue2-ace-editor@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/vue2-ace-editor/-/vue2-ace-editor-0.0.11.tgz#8094a8928f2124fa85a79c2ef2c9c7146c3f7891"
+  integrity sha1-gJSoko8hJPqFp5wu8snHFGw/eJE=
+  dependencies:
+    brace "^0.11.0"
 
 vue@^2.5.17:
   version "2.5.17"

--- a/ui/app/yarn.lock
+++ b/ui/app/yarn.lock
@@ -1453,6 +1453,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -3144,13 +3152,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -3851,6 +3852,13 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "=3.1.0"
 
+follow-redirects@^1.3.0:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -4475,7 +4483,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4938,7 +4946,7 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -5022,14 +5030,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -5871,14 +5871,6 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -8928,11 +8920,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This PR adds a new page in the UI that allows creating a ruleset, this new page can be found in the `ui/app/src/views/NewRuleset/` directory.

The form is split into 3 components:

- `NewRuleset.vue`: the parent page that contains the form and manages the http call to the server
- `Signature.vue`: the component that renders the form for the path + signature of the ruleset
- `Rules.vue`: the component that renders the form for the rules

Other small changes:
- Font Awesome replaced by Material Design Icons
- Fetch replaced by Axios