### PR TITLE
Add ListPaths method

### DIFF
--- a/api/server/api.go
+++ b/api/server/api.go
@@ -80,8 +80,9 @@ func (s *rulesetAPI) get(w http.ResponseWriter, r *http.Request, path string) {
 // the paths parameter is not given otherwise it fetches the rulesets paths only.
 func (s *rulesetAPI) list(w http.ResponseWriter, r *http.Request, prefix string) {
 	var (
-		err   error
-		limit int
+		err     error
+		limit   int
+		entries *store.RulesetEntries
 	)
 
 	if l := r.URL.Query().Get("limit"); l != "" {
@@ -93,8 +94,11 @@ func (s *rulesetAPI) list(w http.ResponseWriter, r *http.Request, prefix string)
 	}
 
 	continueToken := r.URL.Query().Get("continue")
-	_, ok := r.URL.Query()["paths"]
-	entries, err := s.rulesets.List(r.Context(), prefix, limit, continueToken, ok)
+	if _, ok := r.URL.Query()["paths"]; ok {
+		entries, err = s.rulesets.ListPaths(r.Context(), prefix, limit, continueToken)
+	} else {
+		entries, err = s.rulesets.List(r.Context(), prefix, limit, continueToken)
+	}
 
 	if err != nil {
 		if err == store.ErrNotFound {

--- a/mock/store.go
+++ b/mock/store.go
@@ -16,7 +16,9 @@ type RulesetService struct {
 	GetCount         int
 	GetFn            func(ctx context.Context, path, version string) (*store.RulesetEntry, error)
 	ListCount        int
-	ListFn           func(context.Context, string, int, string, bool) (*store.RulesetEntries, error)
+	ListFn           func(context.Context, string, int, string) (*store.RulesetEntries, error)
+	ListPathsCount   int
+	ListPathsFn      func(context.Context, string, int, string) (*store.RulesetEntries, error)
 	WatchCount       int
 	WatchFn          func(context.Context, string, string) (*store.RulesetEvents, error)
 	PutCount         int
@@ -39,11 +41,22 @@ func (s *RulesetService) Get(ctx context.Context, path, version string) (*store.
 }
 
 // List runs ListFn if provided and increments ListCount when invoked.
-func (s *RulesetService) List(ctx context.Context, prefix string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+func (s *RulesetService) List(ctx context.Context, prefix string, limit int, token string) (*store.RulesetEntries, error) {
 	s.ListCount++
 
 	if s.ListFn != nil {
-		return s.ListFn(ctx, prefix, limit, token, pathsOnly)
+		return s.ListFn(ctx, prefix, limit, token)
+	}
+
+	return nil, nil
+}
+
+// ListPaths runs ListPathsFn if provided and increments ListPathsCount when invoked.
+func (s *RulesetService) ListPaths(ctx context.Context, prefix string, limit int, token string) (*store.RulesetEntries, error) {
+	s.ListPathsCount++
+
+	if s.ListPathsFn != nil {
+		return s.ListPathsFn(ctx, prefix, limit, token)
 	}
 
 	return nil, nil

--- a/store/etcd/rulesets_test.go
+++ b/store/etcd/rulesets_test.go
@@ -131,7 +131,7 @@ func TestList(t *testing.T) {
 
 		paths := []string{"a/1", "a", "b", "c"}
 
-		entries, err := s.List(context.Background(), "", 0, "", false)
+		entries, err := s.List(context.Background(), "", 0, "")
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, len(paths))
 		for i, e := range entries.Entries {
@@ -149,7 +149,7 @@ func TestList(t *testing.T) {
 
 		paths := []string{"x/1", "x", "x/2", "xx"}
 
-		entries, err := s.List(context.Background(), "x", 0, "", false)
+		entries, err := s.List(context.Background(), "x", 0, "")
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, len(paths))
 		for i, e := range entries.Entries {
@@ -160,7 +160,7 @@ func TestList(t *testing.T) {
 
 	// NotFound tests List with a prefix which doesn't exist.
 	t.Run("NotFound", func(t *testing.T) {
-		_, err := s.List(context.Background(), "doesntexist", 0, "", false)
+		_, err := s.List(context.Background(), "doesntexist", 0, "")
 		require.Equal(t, err, store.ErrNotFound)
 	})
 
@@ -172,7 +172,7 @@ func TestList(t *testing.T) {
 		createRuleset(t, s, "y/2", rs)
 		createRuleset(t, s, "y/3", rs)
 
-		entries, err := s.List(context.Background(), "y", 2, "", false)
+		entries, err := s.List(context.Background(), "y", 2, "")
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, 2)
 		require.Equal(t, "y/1", entries.Entries[0].Path)
@@ -180,20 +180,20 @@ func TestList(t *testing.T) {
 		require.NotEmpty(t, entries.Continue)
 
 		token := entries.Continue
-		entries, err = s.List(context.Background(), "y", 2, entries.Continue, false)
+		entries, err = s.List(context.Background(), "y", 2, entries.Continue)
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, 2)
 		require.Equal(t, "y/2", entries.Entries[0].Path)
 		require.Equal(t, "y/3", entries.Entries[1].Path)
 		require.NotEmpty(t, entries.Continue)
 
-		entries, err = s.List(context.Background(), "y", 2, entries.Continue, false)
+		entries, err = s.List(context.Background(), "y", 2, entries.Continue)
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, 1)
 		require.Equal(t, "yy", entries.Entries[0].Path)
 		require.Empty(t, entries.Continue)
 
-		entries, err = s.List(context.Background(), "y", 3, token, false)
+		entries, err = s.List(context.Background(), "y", 3, token)
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, 3)
 		require.Equal(t, "y/2", entries.Entries[0].Path)
@@ -201,10 +201,10 @@ func TestList(t *testing.T) {
 		require.Equal(t, "yy", entries.Entries[2].Path)
 		require.Empty(t, entries.Continue)
 
-		entries, err = s.List(context.Background(), "y", 3, "some token", false)
+		entries, err = s.List(context.Background(), "y", 3, "some token")
 		require.Equal(t, store.ErrInvalidContinueToken, err)
 
-		entries, err = s.List(context.Background(), "y", -10, "", false)
+		entries, err = s.List(context.Background(), "y", -10, "")
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, 5)
 	})
@@ -233,7 +233,7 @@ func TestListPaths(t *testing.T) {
 
 		paths := []string{"a", "a/1", "a/2", "b", "c", "d"}
 
-		entries, err := s.List(context.Background(), "", 0, "", true)
+		entries, err := s.ListPaths(context.Background(), "", 0, "")
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, len(paths))
 		for i, e := range entries.Entries {
@@ -256,7 +256,7 @@ func TestListPaths(t *testing.T) {
 
 		paths := []string{"xy", "xy/ab", "xyz"}
 
-		entries, err := s.List(context.Background(), "xy", 0, "", true)
+		entries, err := s.ListPaths(context.Background(), "xy", 0, "")
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, len(paths))
 		for i, e := range entries.Entries {
@@ -270,7 +270,7 @@ func TestListPaths(t *testing.T) {
 
 	// NotFound tests List with a prefix which doesn't exist with pathsOnly parameter set to true.
 	t.Run("NotFound", func(t *testing.T) {
-		_, err := s.List(context.Background(), "doesntexist", 0, "", true)
+		_, err := s.ListPaths(context.Background(), "doesntexist", 0, "")
 		require.Equal(t, err, store.ErrNotFound)
 	})
 
@@ -283,7 +283,7 @@ func TestListPaths(t *testing.T) {
 		createRuleset(t, s, "foo/babar", rs)
 		createRuleset(t, s, "foo", rs)
 
-		entries, err := s.List(context.Background(), "f", 2, "", true)
+		entries, err := s.ListPaths(context.Background(), "f", 2, "")
 		require.NoError(t, err)
 		paths := []string{"foo", "foo/babar"}
 		require.Len(t, entries.Entries, len(paths))
@@ -295,7 +295,7 @@ func TestListPaths(t *testing.T) {
 		require.NotEmpty(t, entries.Revision)
 		require.NotEmpty(t, entries.Continue)
 
-		entries, err = s.List(context.Background(), "f", 2, entries.Continue, true)
+		entries, err = s.ListPaths(context.Background(), "f", 2, entries.Continue)
 		require.NoError(t, err)
 		paths = []string{"foo/bar", "foo/bar/baz"}
 		require.Len(t, entries.Entries, len(paths))
@@ -307,10 +307,10 @@ func TestListPaths(t *testing.T) {
 		require.NotEmpty(t, entries.Revision)
 		require.Zero(t, entries.Continue)
 
-		_, err = s.List(context.Background(), "f", 2, "bad token", true)
+		_, err = s.ListPaths(context.Background(), "f", 2, "bad token")
 		require.Equal(t, store.ErrInvalidContinueToken, err)
 
-		entries, err = s.List(context.Background(), "f", -10, "", true)
+		entries, err = s.ListPaths(context.Background(), "f", -10, "")
 		require.NoError(t, err)
 		paths = []string{"foo", "foo/babar", "foo/bar", "foo/bar/baz"}
 		require.Len(t, entries.Entries, len(paths))

--- a/store/service.go
+++ b/store/service.go
@@ -21,10 +21,14 @@ type RulesetService interface {
 	// Get returns the ruleset related to the given path. By default, it returns the latest one.
 	// It returns the related ruleset version if it's specified.
 	Get(ctx context.Context, path, version string) (*RulesetEntry, error)
-	// List returns the rulesets entries under the given prefix. if pathsOnly is set to true, only the rulesets paths are returned.
+	// List returns the rulesets entries under the given prefix.
 	// If the prefix is empty it returns entries from the beginning following the ascii ordering.
 	// If the given limit is lower or equal to 0 or greater than 100, it returns 50 entries.
-	List(ctx context.Context, prefix string, limit int, continueToken string, pathsOnly bool) (*RulesetEntries, error)
+	List(ctx context.Context, prefix string, limit int, continueToken string) (*RulesetEntries, error)
+	// ListPaths returns rulesets path under the given prefix.
+	// If the prefix is empty it returns paths from the beginning following the ascii ordering.
+	// If the given limit is lower or equal to 0 or greater than 100, it returns 50 paths.
+	ListPaths(ctx context.Context, prefix string, limit int, continueToken string) (*RulesetEntries, error)
 	// Watch a prefix for changes and return a list of events.
 	Watch(ctx context.Context, prefix string, revision string) (*RulesetEvents, error)
 	// Put is used to store a ruleset version.

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -91,7 +91,7 @@ func (h *internalHandler) rulesetsHandler() http.Handler {
 
 		// run the loop at least once, no matter of the value of token
 		for i := 0; i == 0 || token != ""; i++ {
-			list, err := h.service.List(r.Context(), "", 100, token, true)
+			list, err := h.service.ListPaths(r.Context(), "", 100, token)
 			if err != nil {
 				writeError(w, r, err, http.StatusInternalServerError)
 				return

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -29,7 +29,7 @@ func TestInternalHandler(t *testing.T) {
 			s := new(mock.RulesetService)
 
 			// simulate a two page result
-			s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+			s.ListPathsFn = func(ctx context.Context, _ string, limit int, token string) (*store.RulesetEntries, error) {
 				var entries store.RulesetEntries
 
 				switch token {
@@ -61,7 +61,7 @@ func TestInternalHandler(t *testing.T) {
 		// this test checks if the handler returns a 500 if a random error occurs in the ruleset service.
 		t.Run("Error", func(t *testing.T) {
 			s := new(mock.RulesetService)
-			s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+			s.ListPathsFn = func(ctx context.Context, _ string, limit int, token string) (*store.RulesetEntries, error) {
 				return nil, errors.New("some error")
 			}
 


### PR DESCRIPTION
This PR adds the `ListPaths` method to the store.
The things is that the concept of listing is growing inside Regula and we now reach two axis:
- list paths only
- list rulesets (which has differents behaviour):
  - list latest rulesets version
  - list all rulesets version

To ease the legibility of the code and in order to have a source code more maintainable I suggest that we should separate both main concerns (paths vs rulesets).
It is groundwork for #23.

WDYT?