### PR TITLE
Improve api listing

### DIFF
--- a/api/server/api.go
+++ b/api/server/api.go
@@ -80,21 +80,22 @@ func (s *rulesetAPI) get(w http.ResponseWriter, r *http.Request, path string) {
 // the paths parameter is not given otherwise it fetches the rulesets paths only.
 func (s *rulesetAPI) list(w http.ResponseWriter, r *http.Request, prefix string) {
 	var (
-		err   error
-		limit int
+		opt store.ListOptions
+		err error
 	)
 
 	if l := r.URL.Query().Get("limit"); l != "" {
-		limit, err = strconv.Atoi(l)
+		opt.Limit, err = strconv.Atoi(l)
 		if err != nil {
 			writeError(w, r, errors.New("invalid limit"), http.StatusBadRequest)
 			return
 		}
 	}
 
-	continueToken := r.URL.Query().Get("continue")
-	_, ok := r.URL.Query()["paths"]
-	entries, err := s.rulesets.List(r.Context(), prefix, limit, continueToken, ok)
+	opt.ContinueToken = r.URL.Query().Get("continue")
+	_, opt.PathsOnly = r.URL.Query()["paths"]
+
+	entries, err := s.rulesets.List(r.Context(), prefix, &opt)
 
 	if err != nil {
 		if err == store.ErrNotFound {

--- a/api/server/api.go
+++ b/api/server/api.go
@@ -94,6 +94,11 @@ func (s *rulesetAPI) list(w http.ResponseWriter, r *http.Request, prefix string)
 
 	opt.ContinueToken = r.URL.Query().Get("continue")
 	_, opt.PathsOnly = r.URL.Query()["paths"]
+	_, opt.AllVersions = r.URL.Query()["versions"]
+	if opt.PathsOnly && opt.AllVersions {
+		writeError(w, r, errors.New("'paths' and 'versions' parameters can't be given in the same query"), http.StatusBadRequest)
+		return
+	}
 
 	entries, err := s.rulesets.List(r.Context(), prefix, &opt)
 

--- a/api/server/api_test.go
+++ b/api/server/api_test.go
@@ -180,68 +180,17 @@ func TestAPI(t *testing.T) {
 		t.Run("InvalidLimit", func(t *testing.T) {
 			call(t, "/rulesets/someprefix?list&limit=badlimit", http.StatusBadRequest, nil, nil)
 		})
-	})
 
-	t.Run("ListPaths", func(t *testing.T) {
-		l := store.RulesetEntries{
-			Entries: []store.RulesetEntry{
-				{Path: "aa"},
-				{Path: "bb"},
-			},
-			Revision: "somerev",
-			Continue: "sometoken",
-		}
-
-		call := func(t *testing.T, u string, code int, l *store.RulesetEntries, err error) {
-			t.Helper()
-
-			uu, uerr := url.Parse(u)
-			require.NoError(t, uerr)
-			limit := uu.Query().Get("limit")
-			if limit == "" {
-				limit = "0"
-			}
-			token := uu.Query().Get("continue")
-
-			s.ListFn = func(ctx context.Context, prefix string, opt *store.ListOptions) (*store.RulesetEntries, error) {
-				assert.Equal(t, limit, strconv.Itoa(opt.Limit))
-				assert.Equal(t, token, opt.ContinueToken)
-				return l, err
-			}
-			defer func() { s.ListFn = nil }()
-
-			w := httptest.NewRecorder()
-			r := httptest.NewRequest("GET", u, nil)
-			h.ServeHTTP(w, r)
-
-			require.Equal(t, code, w.Code)
-
-			if code == http.StatusOK {
-				var res api.Rulesets
-				err := json.NewDecoder(w.Body).Decode(&res)
-				require.NoError(t, err)
-				require.Equal(t, len(l.Entries), len(res.Rulesets))
-				for i := range l.Entries {
-					require.Equal(t, l.Entries[i].Path, res.Rulesets[i].Path)
-					require.Zero(t, l.Entries[i].Ruleset)
-					require.Zero(t, l.Entries[i].Version)
-				}
-				if len(l.Entries) > 0 {
-					require.Equal(t, "sometoken", res.Continue)
-				}
-			}
-		}
-
-		t.Run("Root", func(t *testing.T) {
-			call(t, "/rulesets/?list&paths", http.StatusOK, &l, nil)
-		})
-
-		t.Run("WithPrefix", func(t *testing.T) {
+		t.Run("PathsParameter", func(t *testing.T) {
 			call(t, "/rulesets/a?list&paths", http.StatusOK, &l, nil)
 		})
 
-		t.Run("WithLimitAndContinue", func(t *testing.T) {
-			call(t, "/rulesets/a?list&paths&limit=10&continue=abc123", http.StatusOK, &l, nil)
+		t.Run("VersionsParameter", func(t *testing.T) {
+			call(t, "/rulesets/a?list&versions", http.StatusOK, &l, nil)
+		})
+
+		t.Run("InvalidParametersCombination", func(t *testing.T) {
+			call(t, "/rulesets/someprefix?list&paths&versions", http.StatusBadRequest, nil, nil)
 		})
 	})
 

--- a/api/server/api_test.go
+++ b/api/server/api_test.go
@@ -122,9 +122,9 @@ func TestAPI(t *testing.T) {
 			}
 			token := uu.Query().Get("continue")
 
-			s.ListFn = func(ctx context.Context, prefix string, lm int, tk string, pathsOnly bool) (*store.RulesetEntries, error) {
-				assert.Equal(t, limit, strconv.Itoa(lm))
-				assert.Equal(t, token, tk)
+			s.ListFn = func(ctx context.Context, prefix string, opt *store.ListOptions) (*store.RulesetEntries, error) {
+				assert.Equal(t, limit, strconv.Itoa(opt.Limit))
+				assert.Equal(t, token, opt.ContinueToken)
 				return l, err
 			}
 			defer func() { s.ListFn = nil }()
@@ -203,9 +203,9 @@ func TestAPI(t *testing.T) {
 			}
 			token := uu.Query().Get("continue")
 
-			s.ListFn = func(ctx context.Context, prefix string, lm int, tk string, pathsOnly bool) (*store.RulesetEntries, error) {
-				assert.Equal(t, limit, strconv.Itoa(lm))
-				assert.Equal(t, token, tk)
+			s.ListFn = func(ctx context.Context, prefix string, opt *store.ListOptions) (*store.RulesetEntries, error) {
+				assert.Equal(t, limit, strconv.Itoa(opt.Limit))
+				assert.Equal(t, token, opt.ContinueToken)
 				return l, err
 			}
 			defer func() { s.ListFn = nil }()

--- a/mock/store.go
+++ b/mock/store.go
@@ -16,7 +16,7 @@ type RulesetService struct {
 	GetCount         int
 	GetFn            func(ctx context.Context, path, version string) (*store.RulesetEntry, error)
 	ListCount        int
-	ListFn           func(context.Context, string, int, string, bool) (*store.RulesetEntries, error)
+	ListFn           func(context.Context, string, *store.ListOptions) (*store.RulesetEntries, error)
 	WatchCount       int
 	WatchFn          func(context.Context, string, string) (*store.RulesetEvents, error)
 	PutCount         int
@@ -39,11 +39,11 @@ func (s *RulesetService) Get(ctx context.Context, path, version string) (*store.
 }
 
 // List runs ListFn if provided and increments ListCount when invoked.
-func (s *RulesetService) List(ctx context.Context, prefix string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+func (s *RulesetService) List(ctx context.Context, prefix string, opt *store.ListOptions) (*store.RulesetEntries, error) {
 	s.ListCount++
 
 	if s.ListFn != nil {
-		return s.ListFn(ctx, prefix, limit, token, pathsOnly)
+		return s.ListFn(ctx, prefix, opt)
 	}
 
 	return nil, nil

--- a/store/etcd/rulesets.go
+++ b/store/etcd/rulesets.go
@@ -23,7 +23,7 @@ import (
 )
 
 // versionSeparator separates the path from the version in the entries path in etcd.
-// The purpose is to have the same ordering with the others namespace (latest, versions, ...).
+// The purpose is to have the same ordering as the others namespace (latest, versions, ...).
 const versionSeparator = "!"
 
 // RulesetService manages the rulesets using etcd.

--- a/store/etcd/rulesets.go
+++ b/store/etcd/rulesets.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"path"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -83,7 +82,7 @@ func (s *RulesetService) Get(ctx context.Context, path, version string) (*store.
 	return entry, nil
 }
 
-// List returns the rulesets entries under the given prefix.  If pathsOnly is set to true, only the rulesets paths will be returned.
+// List returns the latest version of each ruleset under the given prefix.  If pathsOnly is set to true, only the rulesets paths will be returned.
 // If the prefix is empty it returns entries from the beginning following the lexical ordering.
 // If the given limit is lower or equal to 0 or greater than 100, it returns 50 entries.
 func (s *RulesetService) List(ctx context.Context, prefix string, opt *store.ListOptions) (*store.RulesetEntries, error) {
@@ -101,12 +100,7 @@ func (s *RulesetService) List(ctx context.Context, prefix string, opt *store.Lis
 
 		key = string(lastPath)
 
-		var rangeEnd string
-		if opt.PathsOnly {
-			rangeEnd = clientv3.GetPrefixRangeEnd(s.latestRulesetPath(prefix))
-		} else {
-			rangeEnd = clientv3.GetPrefixRangeEnd(s.rulesetsPath(prefix, ""))
-		}
+		rangeEnd := clientv3.GetPrefixRangeEnd(s.latestRulesetPath(prefix))
 		options = append(options, clientv3.WithRange(rangeEnd))
 	} else {
 		key = prefix
@@ -154,9 +148,9 @@ func (s *RulesetService) listPaths(ctx context.Context, key, prefix string, limi
 }
 
 func (s *RulesetService) listRulesets(ctx context.Context, key, prefix string, limit int, opts []clientv3.OpOption) (*store.RulesetEntries, error) {
-	resp, err := s.Client.KV.Get(ctx, s.rulesetsPath(key, ""), opts...)
+	resp, err := s.Client.KV.Get(ctx, s.latestRulesetPath(key), opts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch all entries")
+		return nil, errors.Wrap(err, "failed to fetch latests keys")
 	}
 
 	// if a prefix is provided it must always return results
@@ -165,28 +159,40 @@ func (s *RulesetService) listRulesets(ctx context.Context, key, prefix string, l
 		return nil, store.ErrNotFound
 	}
 
+	ops := make([]clientv3.Op, 0, resp.Count)
+	txn := s.Client.KV.Txn(ctx)
+	for _, pair := range resp.Kvs {
+		ops = append(ops, clientv3.OpGet(string(pair.Value)))
+	}
+	txnresp, err := txn.Then(ops...).Commit()
+	if err != nil {
+		return nil, errors.Wrap(err, "transaction failed to fetch all entries")
+	}
+
 	var entries store.RulesetEntries
 	entries.Revision = strconv.FormatInt(resp.Header.Revision, 10)
 	entries.Entries = make([]store.RulesetEntry, len(resp.Kvs))
-	for i, pair := range resp.Kvs {
-		err = json.Unmarshal(pair.Value, &entries.Entries[i])
+
+	// Responses handles responses for each OpGet calls in the transaction.
+	for i, resps := range txnresp.Responses {
+		rr := resps.GetResponseRange()
+
+		// Given that we are getting a leaf in the tree (a ruleset entry), we are sure that we will always have one value in the Kvs slice.
+		err = json.Unmarshal(rr.Kvs[0].Value, &entries.Entries[i])
 		if err != nil {
-			s.Logger.Debug().Err(err).Bytes("entry", pair.Value).Msg("list: unmarshalling failed")
+			s.Logger.Debug().Err(err).Bytes("entry", rr.Kvs[0].Value).Msg("list: unmarshalling failed")
 			return nil, errors.Wrap(err, "failed to unmarshal entry")
 		}
 	}
 	// The last entry is stored before the sort is applied in case we need it for the pagination.
 	lastEntry := entries.Entries[len(entries.Entries)-1]
 
-	// This sort the entries in the lexical order based on the ruleset's path.
-	sort.SliceStable(entries.Entries, func(i, j int) bool { return entries.Entries[i].Path < entries.Entries[j].Path })
-
 	if len(entries.Entries) < limit || !resp.More {
 		return &entries, nil
 	}
 
 	// we want to start immediately after the last key
-	entries.Continue = base64.URLEncoding.EncodeToString([]byte(path.Join(lastEntry.Path, lastEntry.Version+"\x00")))
+	entries.Continue = base64.URLEncoding.EncodeToString([]byte(lastEntry.Path + "\x00"))
 
 	return &entries, nil
 }

--- a/store/etcd/rulesets.go
+++ b/store/etcd/rulesets.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -174,12 +175,15 @@ func (s *RulesetService) listRulesets(ctx context.Context, key, prefix string, l
 			return nil, errors.Wrap(err, "failed to unmarshal entry")
 		}
 	}
+	// The last entry is stored before the sort is applied in case we need it for the pagination.
+	lastEntry := entries.Entries[len(entries.Entries)-1]
+
+	// This sort the entries in the lexical order based on the ruleset's path.
+	sort.SliceStable(entries.Entries, func(i, j int) bool { return entries.Entries[i].Path < entries.Entries[j].Path })
 
 	if len(entries.Entries) < limit || !resp.More {
 		return &entries, nil
 	}
-
-	lastEntry := entries.Entries[len(entries.Entries)-1]
 
 	// we want to start immediately after the last key
 	entries.Continue = base64.URLEncoding.EncodeToString([]byte(path.Join(lastEntry.Path, lastEntry.Version+"\x00")))

--- a/store/etcd/rulesets_internal_test.go
+++ b/store/etcd/rulesets_internal_test.go
@@ -114,8 +114,11 @@ func TestPathMethods(t *testing.T) {
 		Namespace: "test",
 	}
 
-	exp := "test/rulesets/entries/path" + versionSeparator + "/version"
+	exp := "test/rulesets/entries/path" + versionSeparator + "version"
 	require.Equal(t, exp, s.entriesPath("path", "version"))
+
+	exp = "test/rulesets/entries/path"
+	require.Equal(t, exp, s.entriesPath("path", ""))
 
 	exp = "test/rulesets/checksums/path"
 	require.Equal(t, exp, s.checksumsPath("path"))

--- a/store/etcd/rulesets_internal_test.go
+++ b/store/etcd/rulesets_internal_test.go
@@ -114,8 +114,8 @@ func TestPathMethods(t *testing.T) {
 		Namespace: "test",
 	}
 
-	exp := "test/rulesets/entries/path/version"
-	require.Equal(t, exp, s.rulesetsPath("path", "version"))
+	exp := "test/rulesets/entries/path" + versionSeparator + "/version"
+	require.Equal(t, exp, s.entriesPath("path", "version"))
 
 	exp = "test/rulesets/checksums/path"
 	require.Equal(t, exp, s.checksumsPath("path"))

--- a/store/etcd/rulesets_test.go
+++ b/store/etcd/rulesets_test.go
@@ -142,6 +142,25 @@ func TestList(t *testing.T) {
 		require.NotEmpty(t, entries.Revision)
 	})
 
+	// Assert that only latest version for each ruleset is returned by default.
+	t.Run("Last version only", func(t *testing.T) {
+		prefix := "list/last/version/"
+		rs1, _ := regula.NewBoolRuleset(rule.New(rule.Eq(rule.BoolValue(true), rule.BoolValue(true)), rule.BoolValue(true)))
+		rs2, _ := regula.NewBoolRuleset(rule.New(rule.Eq(rule.StringValue("true"), rule.StringValue("true")), rule.BoolValue(true)))
+
+		createRuleset(t, s, prefix+"a", rs)
+		createRuleset(t, s, prefix+"a/1", rs)
+		createRuleset(t, s, prefix+"a", rs1)
+		createRuleset(t, s, prefix+"a", rs2)
+
+		entries, err := s.List(context.Background(), prefix+"", &store.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, entries.Entries, 2)
+		a := entries.Entries[0]
+		require.Equal(t, rs2, a.Ruleset)
+		require.NotEmpty(t, entries.Revision)
+	})
+
 	// Prefix tests List with a given prefix.
 	t.Run("Prefix", func(t *testing.T) {
 		prefix := "list/prefix/"

--- a/store/etcd/rulesets_test.go
+++ b/store/etcd/rulesets_test.go
@@ -577,7 +577,7 @@ func TestPut(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 1, resp.Count)
 		// verify if the path contains the right ruleset version
-		require.Equal(t, entry.Version, strings.TrimPrefix(string(resp.Kvs[0].Key), ppath.Join(s.Namespace, "rulesets", "entries", "a")+"!/"))
+		require.Equal(t, entry.Version, strings.TrimPrefix(string(resp.Kvs[0].Key), ppath.Join(s.Namespace, "rulesets", "entries", "a")+"!"))
 
 		// verify checksum creation
 		resp, err = s.Client.Get(context.Background(), ppath.Join(s.Namespace, "rulesets", "checksums", path), clientv3.WithPrefix())

--- a/store/service.go
+++ b/store/service.go
@@ -40,7 +40,7 @@ type RulesetService interface {
 type ListOptions struct {
 	Limit         int
 	ContinueToken string
-	PathsOnly     bool // return only the rulesets's path
+	PathsOnly     bool // return only the paths of the rulesets
 	AllVersions   bool // return all versions of each rulesets
 }
 

--- a/store/service.go
+++ b/store/service.go
@@ -24,7 +24,7 @@ type RulesetService interface {
 	// List returns the rulesets entries under the given prefix. if pathsOnly is set to true, only the rulesets paths are returned.
 	// If the prefix is empty it returns entries from the beginning following the ascii ordering.
 	// If the given limit is lower or equal to 0 or greater than 100, it returns 50 entries.
-	List(ctx context.Context, prefix string, limit int, continueToken string, pathsOnly bool) (*RulesetEntries, error)
+	List(ctx context.Context, prefix string, opt *ListOptions) (*RulesetEntries, error)
 	// Watch a prefix for changes and return a list of events.
 	Watch(ctx context.Context, prefix string, revision string) (*RulesetEvents, error)
 	// Put is used to store a ruleset version.
@@ -33,6 +33,13 @@ type RulesetService interface {
 	Eval(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error)
 	// EvalVersion evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
 	EvalVersion(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
+}
+
+// ListOptions contains list options.
+type ListOptions struct {
+	Limit         int
+	ContinueToken string
+	PathsOnly     bool
 }
 
 // RulesetEntry holds a ruleset and its metadata.

--- a/store/service.go
+++ b/store/service.go
@@ -40,6 +40,7 @@ type ListOptions struct {
 	Limit         int
 	ContinueToken string
 	PathsOnly     bool
+	AllVersions   bool // return all versions of each rulesets
 }
 
 // RulesetEntry holds a ruleset and its metadata.

--- a/store/service.go
+++ b/store/service.go
@@ -21,7 +21,7 @@ type RulesetService interface {
 	// Get returns the ruleset related to the given path. By default, it returns the latest one.
 	// It returns the related ruleset version if it's specified.
 	Get(ctx context.Context, path, version string) (*RulesetEntry, error)
-	// List returns the rulesets entries under the given prefix. if pathsOnly is set to true, only the rulesets paths are returned.
+	// List returns the latest version of each ruleset under the given prefix.  If pathsOnly is set to true, only the rulesets paths will be returned.
 	// If the prefix is empty it returns entries from the beginning following the ascii ordering.
 	// If the given limit is lower or equal to 0 or greater than 100, it returns 50 entries.
 	List(ctx context.Context, prefix string, opt *ListOptions) (*RulesetEntries, error)

--- a/store/service.go
+++ b/store/service.go
@@ -21,9 +21,9 @@ type RulesetService interface {
 	// Get returns the ruleset related to the given path. By default, it returns the latest one.
 	// It returns the related ruleset version if it's specified.
 	Get(ctx context.Context, path, version string) (*RulesetEntry, error)
-	// List returns the latest version of each ruleset under the given prefix.  If pathsOnly is set to true, only the rulesets paths will be returned.
-	// If the prefix is empty it returns entries from the beginning following the ascii ordering.
-	// If the given limit is lower or equal to 0 or greater than 100, it returns 50 entries.
+	// List returns the latest version of each ruleset under the given prefix.
+	// If the prefix is empty, it returns entries from the beginning following the lexical order.
+	// The listing can be customised using the ListOptions type.
 	List(ctx context.Context, prefix string, opt *ListOptions) (*RulesetEntries, error)
 	// Watch a prefix for changes and return a list of events.
 	Watch(ctx context.Context, prefix string, revision string) (*RulesetEvents, error)
@@ -36,10 +36,11 @@ type RulesetService interface {
 }
 
 // ListOptions contains list options.
+// If the Limit is lower or equal to 0 or greater than 100, it will be set to 50 by default.
 type ListOptions struct {
 	Limit         int
 	ContinueToken string
-	PathsOnly     bool
+	PathsOnly     bool // return only the rulesets's path
 	AllVersions   bool // return all versions of each rulesets
 }
 

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -87,17 +87,20 @@ func (h *internalHandler) rulesetsHandler() http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var resp response
-		var token string
+		opt := store.ListOptions{
+			Limit:     100,
+			PathsOnly: true,
+		}
 
 		// run the loop at least once, no matter of the value of token
-		for i := 0; i == 0 || token != ""; i++ {
-			list, err := h.service.List(r.Context(), "", 100, token, true)
+		for i := 0; i == 0 || opt.ContinueToken != ""; i++ {
+			list, err := h.service.List(r.Context(), "", &opt)
 			if err != nil {
 				writeError(w, r, err, http.StatusInternalServerError)
 				return
 			}
 
-			token = list.Continue
+			opt.ContinueToken = list.Continue
 			for _, rs := range list.Entries {
 				resp.Rulesets = append(resp.Rulesets, ruleset{Path: rs.Path})
 			}

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -29,10 +29,10 @@ func TestInternalHandler(t *testing.T) {
 			s := new(mock.RulesetService)
 
 			// simulate a two page result
-			s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+			s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
 				var entries store.RulesetEntries
 
-				switch token {
+				switch opt.ContinueToken {
 				case "":
 					for i := 0; i < 2; i++ {
 						entries.Entries = append(entries.Entries, store.RulesetEntry{
@@ -61,7 +61,7 @@ func TestInternalHandler(t *testing.T) {
 		// this test checks if the handler returns a 500 if a random error occurs in the ruleset service.
 		t.Run("Error", func(t *testing.T) {
 			s := new(mock.RulesetService)
-			s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+			s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
 				return nil, errors.New("some error")
 			}
 


### PR DESCRIPTION
The ordering was different when retrieving rulesets for the `versions` parameter from the ordering when retrieving rulesets for the `paths` parameter or for the default behavior (latest version only).

It was complicated to find a way to have the same ordering between each namespaces.

Thus the way the rulesets are stored in the entries namespace in etcd has been updated.
Now the name of the ruleset is suffixed by a `!` (it's the first character in the ascii table) which allows to have a consistent ordering between the namespaces (entries, latest, signatures, ...).

Fix #21 and #23.