### PR TITLE
New ruleset endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,7 @@
 
 
 [[projects]]
+  digest = "1:8bdd161127646f035e63906b6fd7be11a25a16194f92b59214927f1b418f6c22"
   name = "github.com/coreos/etcd"
   packages = [
     "auth/authpb",
@@ -10,121 +11,151 @@
     "etcdserver/api/v3rpc/rpctypes",
     "etcdserver/etcdserverpb",
     "mvcc/mvccpb",
-    "pkg/types"
+    "pkg/types",
   ]
+  pruneopts = "UT"
   revision = "27fc7e2296f506182f58ce846e48f36b34fe6842"
   version = "v3.3.10"
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:bfc758d5a03d57d97226fac6934551c01bd76612adb119c177395b057a0a46db"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
     "proto",
-    "protoc-gen-gogo/descriptor"
+    "protoc-gen-gogo/descriptor",
   ]
+  pruneopts = "UT"
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:2b7795576f6f15c68487b332fcdd723ef52df627fa34a57d62255d6d1349482d"
   name = "github.com/heetch/confita"
   packages = [
     ".",
     "backend",
     "backend/env",
-    "backend/flags"
+    "backend/flags",
   ]
+  pruneopts = "UT"
   revision = "67096f89cfbe7bfed88e320a8bf4399f50a29667"
   version = "v0.5.1"
 
 [[projects]]
+  digest = "1:0981502f9816113c9c8c4ac301583841855c8cf4da8c72f696b3ebedf6d0e4e5"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
   version = "v0.0.4"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:2e76a73cb51f42d63a2a1a85b3dc5731fd4faf6821b434bd0ef2c099186031d6"
   name = "github.com/rs/xid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "15d26544def341f036c5f8dca987a4cbe575032c"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:558898f9fcf9230cb12f424c05c720fc6ab5701ca82727bc77d9d38ae4eb14a6"
   name = "github.com/rs/zerolog"
   packages = [
     ".",
     "hlog",
     "internal/cbor",
     "internal/json",
-    "log"
+    "log",
   ]
+  pruneopts = "UT"
   revision = "3f112dae87cc442ae64da296e41591b64a52529f"
   version = "v1.10.1"
 
 [[projects]]
+  digest = "1:c2a594011eed07da14918c519a5b1d08e4bafb2497037f6a426dc310428df4d3"
   name = "github.com/segmentio/ksuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ffd9a8aaaf8f40792e055371eba06542348e991e"
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:2cab41f59638fdb77dda96ab4f9b5860ef30f48967557254eba127e43c756f2e"
   name = "github.com/tidwall/gjson"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1e3f6aeaa5bad08d777ea7807b279a07885dd8b2"
   version = "v1.1.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:d3f968e2a2c9f8506ed44b01b605ade0176ba6cf73ff679073e77cfdef2c0d55"
   name = "github.com/tidwall/match"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1731857f09b1f38450e2c12409748407822dc6be"
 
 [[projects]]
+  digest = "1:f23222558887a5919f8e9021ecb205395de463f031dd0c049e6e8e547b57c3f4"
   name = "github.com/zenazn/goji"
   packages = ["web/mutil"]
+  pruneopts = "UT"
   revision = "64eb34159fe53473206c2b3e70fe396a639452f2"
   version = "v1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:65c765afa6bd03160739504fefac7774864cf47356f9cd008e251b17854f43dd"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -134,17 +165,21 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
+  pruneopts = "UT"
   revision = "03003ca0c849e57b6ea29a4bab8d3cb6e4d568fe"
 
 [[projects]]
   branch = "master"
+  digest = "1:7ba061af4131fb44b30448572acd0d6fefbf63a61b97b7ef1dea0be5871c2742"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
 
 [[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -160,18 +195,22 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:56b0bca90b7e5d1facf5fbdacba23e4e0ce069d25381b8e2f70ef1e7ebfb9c1a"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "UT"
   revision = "5fc9ac5403620be16bcdb0c8e7644b1178472c3b"
 
 [[projects]]
+  digest = "1:bf7e2328a58176b7f29f3b425b0555745e9a18ed803f5fd8f6c2c13913a60bb4"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -200,14 +239,32 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap"
+    "tap",
   ]
+  pruneopts = "UT"
   revision = "2e463a05d100327ca47ac218281906921038fd95"
   version = "v1.16.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ec00bf4786126c0ac9f2050e8dc7e33cac48b415c6035832a24df5a7824f17b0"
+  input-imports = [
+    "github.com/coreos/etcd/clientv3",
+    "github.com/coreos/etcd/clientv3/concurrency",
+    "github.com/coreos/etcd/mvcc/mvccpb",
+    "github.com/heetch/confita",
+    "github.com/heetch/confita/backend",
+    "github.com/heetch/confita/backend/env",
+    "github.com/heetch/confita/backend/flags",
+    "github.com/mattn/go-isatty",
+    "github.com/pkg/errors",
+    "github.com/rs/zerolog",
+    "github.com/rs/zerolog/hlog",
+    "github.com/segmentio/ksuid",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "github.com/tidwall/gjson",
+    "golang.org/x/net/context/ctxhttp",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/rule/contract.go
+++ b/rule/contract.go
@@ -1,6 +1,9 @@
 package rule
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Type represents the type of a typed expression.  Any expression has
 // a return type, and some expressions also receive typed parameters.
@@ -18,6 +21,7 @@ const (
 	FLOAT
 	NUMBER // A special type that can be promoted to INTEGER or FLOAT
 	ANY    // A special type that can be promoted to any other.
+	INVALID
 )
 
 // String returns a human readable representation of the Type.  This
@@ -38,6 +42,27 @@ func (t Type) String() string {
 		return "Any"
 	}
 	return "invalid type"
+}
+
+// TypeFromName takes a string representation of a type and returns
+// the corresponding Type, or an error.
+func TypeFromName(name string) (Type, error) {
+	ts := strings.TrimSpace((strings.ToLower(name)))
+	switch ts {
+	case "bool", "boolean":
+		return BOOLEAN, nil
+	case "string":
+		return STRING, nil
+	case "integer", "int", "int64":
+		return INTEGER, nil
+	case "float", "float64":
+		return FLOAT, nil
+	case "number":
+		return NUMBER, nil
+	case "any":
+		return ANY, nil
+	}
+	return INVALID, fmt.Errorf("Invalid Type: %s", name)
 }
 
 // Cardinality expresses the number of times a term might be repeated

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -112,7 +112,6 @@ func (h *internalHandler) handleNewRulesetRequest(w http.ResponseWriter, r *http
 
 // handleListRequest attempts to return a list of Rulesets based on the data provided in a GET request to the ruleset endpoint.
 func (h *internalHandler) handleListRequest(w http.ResponseWriter, r *http.Request) {
-
 	type ruleset struct {
 		Path string `json:"path"`
 	}
@@ -122,7 +121,6 @@ func (h *internalHandler) handleListRequest(w http.ResponseWriter, r *http.Reque
 	}
 
 	var resp response
-
 	opt := store.ListOptions{
 		Limit:     100,
 		PathsOnly: true,
@@ -140,10 +138,9 @@ func (h *internalHandler) handleListRequest(w http.ResponseWriter, r *http.Reque
 		for _, rs := range list.Entries {
 			resp.Rulesets = append(resp.Rulesets, ruleset{Path: rs.Path})
 		}
-
-		reghttp.EncodeJSON(w, r, &resp, http.StatusOK)
 	}
 
+	reghttp.EncodeJSON(w, r, &resp, http.StatusOK)
 }
 
 // Returns an http handler that lists all existing rulesets paths.

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -91,12 +90,8 @@ func newInternalHandler(service store.RulesetService) http.Handler {
 // handleNewRulesetRequest consumes a POST to the ruleset endpoint and
 // attempts to create a new Ruleset from that data.
 func (h *internalHandler) handleNewRulesetRequest(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		writeError(w, r, err, http.StatusBadRequest)
-	}
 	nrr := &newRulesetRequest{}
-	err = json.Unmarshal(body, nrr)
+	err := json.NewDecoder(r.Body).Decode(nrr)
 	if err != nil {
 		writeError(w, r, err, http.StatusBadRequest)
 		return

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -1,11 +1,19 @@
 package ui
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"path/filepath"
+	"strconv"
 
+	"github.com/heetch/regula"
 	reghttp "github.com/heetch/regula/http"
+	regrule "github.com/heetch/regula/rule"
+	"github.com/heetch/regula/rule/sexpr"
 	"github.com/heetch/regula/store"
 )
 
@@ -77,6 +85,7 @@ func newInternalHandler(service store.RulesetService) http.Handler {
 
 // Returns an http handler that lists all existing rulesets paths.
 func (h *internalHandler) rulesetsHandler() http.Handler {
+
 	type ruleset struct {
 		Path string `json:"path"`
 	}
@@ -86,23 +95,203 @@ func (h *internalHandler) rulesetsHandler() http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var resp response
-		var token string
-
-		// run the loop at least once, no matter of the value of token
-		for i := 0; i == 0 || token != ""; i++ {
-			list, err := h.service.List(r.Context(), "", 100, token, true)
+		switch r.Method {
+		case "POST":
+			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
-				writeError(w, r, err, http.StatusInternalServerError)
+				writeError(w, r, err, http.StatusBadRequest)
+			}
+			nrr := &newRulesetRequest{}
+			err = json.Unmarshal(body, nrr)
+			if err != nil {
+				writeError(w, r, err, http.StatusBadRequest)
 				return
 			}
-
-			token = list.Continue
-			for _, rs := range list.Entries {
-				resp.Rulesets = append(resp.Rulesets, ruleset{Path: rs.Path})
+			rs, err := newRulesetFromRequest(nrr)
+			if err != nil {
+				writeError(w, r, err, http.StatusBadRequest)
+				return
 			}
+			_, err = h.service.Put(r.Context(), nrr.Path, rs)
+			if err != nil {
+				writeError(w, r, err, http.StatusBadRequest)
+				return
+			}
+			reghttp.EncodeJSON(w, r, nil, http.StatusOK)
+		case "GET":
+			var resp response
+			var token string
+
+			// run the loop at least once, no matter of the value of token
+			for i := 0; i == 0 || token != ""; i++ {
+				list, err := h.service.List(r.Context(), "", 100, token, true)
+				if err != nil {
+					writeError(w, r, err, http.StatusInternalServerError)
+					return
+				}
+
+				token = list.Continue
+				for _, rs := range list.Entries {
+					resp.Rulesets = append(resp.Rulesets, ruleset{Path: rs.Path})
+				}
+			}
+
+			reghttp.EncodeJSON(w, r, &resp, http.StatusOK)
 		}
 
-		reghttp.EncodeJSON(w, r, &resp, http.StatusOK)
 	})
+}
+
+type param map[string]string
+
+type signature struct {
+	Params     []param `json:"params"`
+	ReturnType string
+}
+
+type rule struct {
+	SExpr       string `json:"sExpr"`
+	ReturnValue string `json:"returnValue"`
+}
+
+type newRulesetRequest struct {
+	Path      string    `json:"path"`
+	Signature signature `json:"signature"`
+	Rules     []rule    `json:"rules"`
+}
+
+func convertParams(input []param) (sexpr.Parameters, error) {
+	parm := make(sexpr.Parameters)
+	for _, p := range input {
+		for k, v := range p {
+			t, err := regrule.TypeFromName(v)
+			if err != nil {
+				return nil, err
+			}
+			parm[k] = t
+		}
+	}
+	return parm, nil
+}
+
+func newRulesetFromRequest(nrr *newRulesetRequest) (*regula.Ruleset, error) {
+	var rules []*regrule.Rule
+	parm, err := convertParams(nrr.Signature.Params)
+	if err != nil {
+		return nil, err
+	}
+
+	for n, rule := range nrr.Rules {
+		p := sexpr.NewParser(bytes.NewBufferString(rule.SExpr))
+		expr, err := p.Parse(parm)
+		if err != nil {
+			return nil, newRuleError(n+1, err)
+		}
+		val, err := makeValue(nrr.Signature.ReturnType, rule.ReturnValue)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, &regrule.Rule{
+			Expr:   expr,
+			Result: val,
+		})
+
+	}
+
+	return makeRuleset(nrr.Signature.ReturnType, rules...)
+}
+
+//
+func makeValue(returnType, returnValue string) (*regrule.Value, error) {
+	switch returnType {
+	case "string":
+		return regrule.StringValue(returnValue), nil
+	case "bool":
+		b, err := strconv.ParseBool(returnValue)
+		if err != nil {
+			return nil, err
+		}
+		return regrule.BoolValue(b), nil
+	case "int64":
+		i, err := strconv.ParseInt(returnValue, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		return regrule.Int64Value(i), nil
+	case "float64":
+		f, err := strconv.ParseFloat(returnValue, 64)
+		if err != nil {
+			return nil, err
+		}
+		return regrule.Float64Value(f), nil
+	}
+	return nil, fmt.Errorf("Invalid return type %q", returnType)
+}
+
+func makeRuleset(returnType string, rules ...*regrule.Rule) (*regula.Ruleset, error) {
+	switch returnType {
+	case "string":
+		return regula.NewStringRuleset(rules...)
+	case "bool":
+		return regula.NewBoolRuleset(rules...)
+	case "int64":
+		return regula.NewInt64Ruleset(rules...)
+	case "float64":
+		return regula.NewFloat64Ruleset(rules...)
+	}
+	return nil, fmt.Errorf("Invalid return type %q", returnType)
+}
+
+type RuleError struct {
+	ruleNum int
+	err     error
+}
+
+func newRuleError(ruleNum int, qerr error) *RuleError {
+	return &RuleError{ruleNum: ruleNum, err: err}
+}
+
+//
+func (re *RuleError) Error() string {
+	pe, ok := re.err.(sexpr.ParserError)
+	if !ok {
+		return re.err.Error()
+	}
+	return fmt.Sprintf("%s in rule %d: %s", pe.ErrorType, re.ruleNum, pe.Msg)
+}
+
+//
+func (re *RuleError) MarshalJSON() ([]byte, error) {
+	type field struct {
+		Path  []string `json:"path"`
+		Error struct {
+			Message string `json:"message"`
+			Line    int    `json:"line"`
+			Char    int    `json:"char"`
+			AbsChar int    `json:"absChar"`
+		} `json:"error"`
+	}
+
+	var err struct {
+		Error  string  `json:"error"`
+		Fields []field `json:"fields"`
+	}
+	errMsg := re.Error()
+	err.Error = errMsg
+	pe, ok := re.err.(sexpr.ParserError)
+	if !ok {
+		return json.Marshal(err)
+	}
+	err.Fields = []field{
+		{
+			Path: []string{"rules", strconv.Itoa(err.ruleNum), "sExpr"},
+			Error: {
+				Message: errMsg,
+				Line:    pe.StartLine,
+				Char:    pe.StartCharInLine,
+				AbsChar: StartChar,
+			},
+		},
+	}
+	return json.Marshal(err)
 }

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -183,7 +183,7 @@ type newRulesetRequest struct {
 }
 
 // convertParams takes a slice of param, unmarshalled from a
-// newRulesetRequest, and returns an equivalent sexpr.Paramaters map.
+// newRulesetRequest, and returns an equivalent sexpr.Parameters map.
 func convertParams(input []param) (sexpr.Parameters, error) {
 	parm := make(sexpr.Parameters)
 	for _, p := range input {

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -111,7 +111,7 @@ func (h *internalHandler) handleNewRulesetRequest(w http.ResponseWriter, r *http
 		writeError(w, r, err, http.StatusBadRequest)
 		return
 	}
-	reghttp.EncodeJSON(w, r, nil, http.StatusOK)
+	reghttp.EncodeJSON(w, r, nil, http.StatusCreated)
 
 }
 

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -22,9 +22,10 @@ func doRequest(h http.Handler, method, path string, body io.Reader) *httptest.Re
 	return w
 }
 
-func TestPOST(t *testing.T) {
+func TestPOSTNewRulesetWithParserError(t *testing.T) {
 	s := new(mock.RulesetService)
-	rec := doRequest(NewHandler(s, ""), "POST", "/i/rulesets/", strings.NewReader(`{
+	rec := doRequest(NewHandler(s, ""), "POST", "/i/rulesets/",
+		strings.NewReader(`{
     "path": "Path1",
     "signature": {
         "params": [
@@ -58,62 +59,74 @@ func TestPOST(t *testing.T) {
     ]
 }
 `, body)
+	require.Equal(t, 0, s.PutCount)
+}
+
+func TestPOSTNewRuleset(t *testing.T) {
+	s := new(mock.RulesetService)
+	rec := doRequest(NewHandler(s, ""), "POST", "/i/rulesets/",
+		strings.NewReader(`{
+    "path": "Path1",
+    "signature": {
+        "params": [
+            {
+                "foo": "string"
+            }
+        ],
+        "returnType": "string"
+    },
+    "rules": [
+        {
+            "sExpr": "(= 1 1)",
+            "returnValue": "wibble"
+        }
+    ]
+}`))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 1, s.PutCount)
 }
 
 func TestInternalHandler(t *testing.T) {
-	t.Run("Rulesets", func(t *testing.T) {
-		// POSTing to the ruleset endpoint attempts to create a new ruleset
-		// t.Run("POST", func(t *testing.T) {
-		// 	// Posting invalid ruleset data returns an error.
-		//      t.Run("Validation Error", func(t *testing.T) {
+	// this test checks if the handler deals with pagination correctly
+	// and returns the right payload
+	t.Run("OK", func(t *testing.T) {
+		s := new(mock.RulesetService)
 
-		// 	})
-		// })
+		// simulate a two page result
+		s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
+			var entries store.RulesetEntries
 
-		// GETting the ruleset endpoint returns a list of rulsets
-		t.Run("GET", func(t *testing.T) {
-			// this test checks if the handler deals with pagination correctly
-			// and returns the right payload
-			t.Run("OK", func(t *testing.T) {
-				s := new(mock.RulesetService)
-
-				// simulate a two page result
-				s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
-					var entries store.RulesetEntries
-
-					switch opt.ContinueToken {
-					case "":
-						for i := 0; i < 2; i++ {
-							entries.Entries = append(entries.Entries, store.RulesetEntry{
-								Path: fmt.Sprintf("Path%d", i),
-							})
-						}
-
-						entries.Continue = "continue"
-					case "continue":
-						for i := 2; i < 3; i++ {
-							entries.Entries = append(entries.Entries, store.RulesetEntry{
-								Path: fmt.Sprintf("Path%d", i),
-							})
-						}
-						entries.Continue = ""
-					}
-
-					return &entries, nil
+			switch opt.ContinueToken {
+			case "":
+				for i := 0; i < 2; i++ {
+					entries.Entries = append(entries.Entries, store.RulesetEntry{
+						Path: fmt.Sprintf("Path%d", i),
+					})
 				}
 
-				rec := doRequest(NewHandler(s, ""), "GET", "/i/rulesets/", nil)
-				require.Equal(t, http.StatusOK, rec.Code)
-				require.JSONEq(t, `{"rulesets": [{"path": "Path0"},{"path": "Path1"},{"path": "Path2"}]}`, rec.Body.String())
-			})
-
-			// this test checks if the handler returns a 500 if a random error occurs in the ruleset service.
-			t.Run("Error", func(t *testing.T) {
-				s := new(mock.RulesetService)
-				s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
-					return nil, errors.New("some error")
+				entries.Continue = "continue"
+			case "continue":
+				for i := 2; i < 3; i++ {
+					entries.Entries = append(entries.Entries, store.RulesetEntry{
+						Path: fmt.Sprintf("Path%d", i),
+					})
 				}
-			})
-		})
+				entries.Continue = ""
+			}
+
+			return &entries, nil
+		}
+
+		rec := doRequest(NewHandler(s, ""), "GET", "/i/rulesets/", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.JSONEq(t, `{"rulesets": [{"path": "Path0"},{"path": "Path1"},{"path": "Path2"}]}`, rec.Body.String())
+	})
+
+	// this test checks if the handler returns a 500 if a random error occurs in the ruleset service.
+	t.Run("Error", func(t *testing.T) {
+		s := new(mock.RulesetService)
+		s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
+			return nil, errors.New("some error")
+		}
 	})
 }

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -82,7 +82,7 @@ func TestPOSTNewRuleset(t *testing.T) {
         }
     ]
 }`))
-	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusCreated, rec.Code)
 	require.Equal(t, 1, s.PutCount)
 }
 

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/heetch/regula/mock"
@@ -21,52 +22,103 @@ func doRequest(h http.Handler, method, path string, body io.Reader) *httptest.Re
 	return w
 }
 
+func TestPOST(t *testing.T) {
+	s := new(mock.RulesetService)
+	rec := doRequest(NewHandler(s, ""), "POST", "/i/rulesets/", strings.NewReader(`{
+    "path": "Path1",
+    "signature": {
+        "params": [
+            {
+                "foo": "string"
+            }
+        ],
+        "returnType": "string"
+    },
+    "rules": [
+        {
+            "sExpr": "(= 1 1",
+            "returnValue": "wibble"
+        }
+    ]
+}`))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	t.Logf("JSON: %q", body)
+	require.JSONEq(t, `{
+	    "error": "unexpected end of file whilst parsing rule",
+	    "fields": [
+		{
+		    "path": ["rules", "2", "sExpr"],
+		    "error": {
+			"message": "unexpected end of file whilst parsing rule",
+			"line": 10,
+			"char": 11,
+			"absChar": 120
+		    }
+		},
+	    ]
+	}
+	`, body)
+}
+
 func TestInternalHandler(t *testing.T) {
 	t.Run("Rulesets", func(t *testing.T) {
-		// this test checks if the handler deals with pagination correctly
-		// and returns the right payload
-		t.Run("OK", func(t *testing.T) {
-			s := new(mock.RulesetService)
+		// POSTing to the ruleset endpoint attempts to create a new ruleset
+		// t.Run("POST", func(t *testing.T) {
+		// 	// Posting invalid ruleset data returns an error.
+		//      t.Run("Validation Error", func(t *testing.T) {
 
-			// simulate a two page result
-			s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
-				var entries store.RulesetEntries
+		// 	})
+		// })
 
-				switch token {
-				case "":
-					for i := 0; i < 2; i++ {
-						entries.Entries = append(entries.Entries, store.RulesetEntry{
-							Path: fmt.Sprintf("Path%d", i),
-						})
+		// GETting the ruleset endpoint returns a list of rulsets
+		t.Run("GET", func(t *testing.T) {
+			// this test checks if the handler deals with pagination correctly
+			// and returns the right payload
+			t.Run("OK", func(t *testing.T) {
+				s := new(mock.RulesetService)
+
+				// simulate a two page result
+				s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+					var entries store.RulesetEntries
+
+					switch token {
+					case "":
+						for i := 0; i < 2; i++ {
+							entries.Entries = append(entries.Entries, store.RulesetEntry{
+								Path: fmt.Sprintf("Path%d", i),
+							})
+						}
+
+						entries.Continue = "continue"
+					case "continue":
+						for i := 2; i < 3; i++ {
+							entries.Entries = append(entries.Entries, store.RulesetEntry{
+								Path: fmt.Sprintf("Path%d", i),
+							})
+						}
+						entries.Continue = ""
 					}
 
-					entries.Continue = "continue"
-				case "continue":
-					for i := 2; i < 3; i++ {
-						entries.Entries = append(entries.Entries, store.RulesetEntry{
-							Path: fmt.Sprintf("Path%d", i),
-						})
-					}
-					entries.Continue = ""
+					return &entries, nil
 				}
 
-				return &entries, nil
-			}
+				rec := doRequest(NewHandler(s, ""), "GET", "/i/rulesets/", nil)
+				require.Equal(t, http.StatusOK, rec.Code)
+				require.JSONEq(t, `{"rulesets": [{"path": "Path0"},{"path": "Path1"},{"path": "Path2"}]}`, rec.Body.String())
+			})
 
-			rec := doRequest(NewHandler(s, ""), "GET", "/i/rulesets/", nil)
-			require.Equal(t, http.StatusOK, rec.Code)
-			require.JSONEq(t, `{"rulesets": [{"path": "Path0"},{"path": "Path1"},{"path": "Path2"}]}`, rec.Body.String())
-		})
+			// this test checks if the handler returns a 500 if a random error occurs in the ruleset service.
+			t.Run("Error", func(t *testing.T) {
+				s := new(mock.RulesetService)
+				s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+					return nil, errors.New("some error")
+				}
 
-		// this test checks if the handler returns a 500 if a random error occurs in the ruleset service.
-		t.Run("Error", func(t *testing.T) {
-			s := new(mock.RulesetService)
-			s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
-				return nil, errors.New("some error")
-			}
+				rec := doRequest(NewHandler(s, ""), "GET", "/i/rulesets/", nil)
+				require.Equal(t, http.StatusInternalServerError, rec.Code)
+			})
 
-			rec := doRequest(NewHandler(s, ""), "GET", "/i/rulesets/", nil)
-			require.Equal(t, http.StatusInternalServerError, rec.Code)
 		})
 	})
 }

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -43,22 +43,21 @@ func TestPOST(t *testing.T) {
 }`))
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	body := rec.Body.String()
-	t.Logf("JSON: %q", body)
 	require.JSONEq(t, `{
-	    "error": "unexpected end of file whilst parsing rule",
-	    "fields": [
-		{
-		    "path": ["rules", "2", "sExpr"],
-		    "error": {
-			"message": "unexpected end of file whilst parsing rule",
-			"line": 10,
-			"char": 11,
-			"absChar": 120
-		    }
-		},
-	    ]
+    "error": "Error in rule 1: unexpected end of file",
+    "fields": [
+	{
+	    "path": ["rules", "1", "sExpr"],
+	    "error": {
+		"message": "Error in rule 1: unexpected end of file",
+		"line": 1,
+		"char": 6,
+		"absChar": 6
+	 }
 	}
-	`, body)
+    ]
+}
+`, body)
 }
 
 func TestInternalHandler(t *testing.T) {
@@ -68,7 +67,6 @@ func TestInternalHandler(t *testing.T) {
 		// 	// Posting invalid ruleset data returns an error.
 		//      t.Run("Validation Error", func(t *testing.T) {
 
-<<<<<<< HEAD
 		// 	})
 		// })
 
@@ -80,23 +78,10 @@ func TestInternalHandler(t *testing.T) {
 				s := new(mock.RulesetService)
 
 				// simulate a two page result
-				s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+				s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
 					var entries store.RulesetEntries
-=======
-			// simulate a two page result
-			s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
-				var entries store.RulesetEntries
 
-				switch opt.ContinueToken {
-				case "":
-					for i := 0; i < 2; i++ {
-						entries.Entries = append(entries.Entries, store.RulesetEntry{
-							Path: fmt.Sprintf("Path%d", i),
-						})
-					}
->>>>>>> release-v0.6.0
-
-					switch token {
+					switch opt.ContinueToken {
 					case "":
 						for i := 0; i < 2; i++ {
 							entries.Entries = append(entries.Entries, store.RulesetEntry{
@@ -125,23 +110,10 @@ func TestInternalHandler(t *testing.T) {
 			// this test checks if the handler returns a 500 if a random error occurs in the ruleset service.
 			t.Run("Error", func(t *testing.T) {
 				s := new(mock.RulesetService)
-				s.ListFn = func(ctx context.Context, _ string, limit int, token string, pathsOnly bool) (*store.RulesetEntries, error) {
+				s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
 					return nil, errors.New("some error")
 				}
-
-<<<<<<< HEAD
-				rec := doRequest(NewHandler(s, ""), "GET", "/i/rulesets/", nil)
-				require.Equal(t, http.StatusInternalServerError, rec.Code)
 			})
-=======
-		// this test checks if the handler returns a 500 if a random error occurs in the ruleset service.
-		t.Run("Error", func(t *testing.T) {
-			s := new(mock.RulesetService)
-			s.ListFn = func(ctx context.Context, _ string, opt *store.ListOptions) (*store.RulesetEntries, error) {
-				return nil, errors.New("some error")
-			}
->>>>>>> release-v0.6.0
-
 		})
 	})
 }


### PR DESCRIPTION
This PR implements a handler for POSTs to the ruleset endpoint from the UI, in accordance with the issue #31 

On receipt of POST to the `/ui/i/rulesets` endpoint we attempt to:
- unmarshal the payload into a struct, 
- convert that structure into a `regula.Ruleset` and its `regula.rule.Rule`(s).  This step involves the symbolic expression parser parsing each rule.  
- Return either a StatusCreated (HTTP 201) or a StatusBadRequest (HTTP 400)

Mostly of this branch is self evident, but I did restructure the request handler to now cope with POST as well as GET requests.  