### PR TITLE
Add branching conditional (If) operator

### DIFF
--- a/rule/control_expr.go
+++ b/rule/control_expr.go
@@ -4,6 +4,10 @@ func init() {
 	Operators["let"] = func() Operator { return newExprLet() }
 }
 
+//////////////////
+// Let operator //
+//////////////////
+
 type exprLet struct {
 	operator
 }
@@ -91,4 +95,69 @@ func (n *exprLet) Eval(params Params) (*Value, error) {
 
 	// Evaluate the body form within the new scope
 	return n.operands[2].Eval(scopedParams)
+}
+
+/////////////////
+// If operator //
+/////////////////
+
+type exprIf struct {
+	operator
+}
+
+// Note that if's contract has two Body expressions, both of these *must* have the same type.
+func newExprIf() *exprIf {
+	return &exprIf{
+		operator: operator{
+			contract: Contract{
+				OpCode:     "if",
+				ReturnType: ANY,
+				Terms: []Term{
+					{
+						Type:        BOOLEAN,
+						Cardinality: ONE,
+					},
+					{
+						Type:        ANY,
+						Cardinality: ONE,
+						IsBody:      true,
+					},
+					{
+						Type:        ANY,
+						Cardinality: ONE,
+						IsBody:      true,
+					},
+				},
+			},
+		},
+	}
+}
+
+// If creates an expression that will cause evaluation to choose one
+// of two body blocks based on a boolean expression. The boolean
+// expression is provided as the "test" parameter.  If the "test"
+// evaluates to true, then the expression passed as the "truePart"
+// will be evaluated, otherwise the expression passed at the
+// "falsePart" will be evaluated.  Note that the return type of the
+// "truePart" and "falsePart" must be the same.
+func If(test Expr, truePart Expr, falsePart Expr) Expr {
+	e := newExprIf()
+	e.pushExprOrPanic(test)
+	e.pushExprOrPanic(truePart)
+	e.pushExprOrPanic(falsePart)
+	e.finaliseOrPanic()
+	return e
+}
+
+// Eval makes exprIf comply with the Expr interface.
+func (n *exprIf) Eval(params Params) (*Value, error) {
+	cond, err := exprToBool(n.operands[0], params)
+	if err != nil {
+		return nil, err
+	}
+
+	if cond {
+		return n.operands[1].Eval(params)
+	}
+	return n.operands[2].Eval(params)
 }

--- a/rule/control_expr.go
+++ b/rule/control_expr.go
@@ -2,6 +2,7 @@ package rule
 
 func init() {
 	Operators["let"] = func() Operator { return newExprLet() }
+	Operators["if"] = func() Operator { return newExprIf() }
 }
 
 //////////////////

--- a/rule/control_expr_test.go
+++ b/rule/control_expr_test.go
@@ -18,3 +18,21 @@ func TestLet(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.Same(rule.Int64Value(10)))
 }
+
+func TestIf(t *testing.T) {
+	params := make(regula.Params)
+	i := rule.If(rule.BoolValue(true),
+		rule.BoolValue(true),
+		rule.BoolValue(false))
+	result, err := i.Eval(params)
+	require.NoError(t, err)
+	require.True(t, result.Same(rule.BoolValue(true)))
+
+	i = rule.If(rule.BoolValue(false),
+		rule.BoolValue(true),
+		rule.BoolValue(false))
+	result, err = i.Eval(params)
+	require.NoError(t, err)
+	require.True(t, result.Same(rule.BoolValue(false)))
+
+}

--- a/rule/sexpr/assertions.lisp
+++ b/rule/sexpr/assertions.lisp
@@ -52,4 +52,8 @@
 (assert= 10 (let x 10 x))               ; Return bound value from let
 (assert= 10 (let x (+ 5 5) x))          ; Let identifier equal result of value form
 (assert= #true (let f #false (not f)))  ; Operate on bound value
-
+(assert= #true (if #true #true #false)) ; If returns the true-part when the condition is true
+(assert= #false (if #false #true #false)) ; If returns the false-part when the condition is false
+(assert= #true (if (= 2 (+ 1 1)) #true #false)) ; If tests can be nested expressions
+(assert= #true (if #true (= 2 (+ 1 1)) #false)) ; If true-parts can be nested expressions
+(assert= #false (if #false #true (= 3 (+ 1 1)))) ; If false-parts can be nested expressions

--- a/rule/sexpr/parser.go
+++ b/rule/sexpr/parser.go
@@ -32,6 +32,7 @@ func makeSymbolMap() *opCodeMap {
 	sm.mapSymbol("percentile", "percentile")
 	sm.mapSymbol("int->float", "intToFloat")
 	sm.mapSymbol("let", "let")
+	sm.mapSymbol("if", "if")
 	return sm
 }
 


### PR DESCRIPTION
When adding mathematical operators to regula's expressions we noticed that one can create error conditions (divide by zero).  To make it possible for people writing rules to evade such conditions one must have a conditional branching operator that only evaluates one outcome.  The simplest form to create, and to use, is the two branch "if" operator.  So here it is.  

One should note that this operator has two terms marked "isBody: true" in the contract.  Both of these terms must be fulfilled by operands with the same `ReturnType` in their contract.