### PR TITLE
Implement Less-than operator (<)

### DIFF
--- a/rule/eq_expr.go
+++ b/rule/eq_expr.go
@@ -147,6 +147,28 @@ func (n *exprLT) floatLT(params Params) (*Value, error) {
 	return BoolValue(true), nil
 }
 
+// perform a less-than comparison on a sequence of strings
+func (n *exprLT) stringLT(params Params) (*Value, error) {
+	var s0, s1 string
+	var err error
+
+	s0, err = exprToString(n.operands[0], params)
+	if err != nil {
+		return nil, err
+	}
+	for j := 1; j < len(n.operands); j++ {
+		s1, err = exprToString(n.operands[j], params)
+		if err != nil {
+			return nil, err
+		}
+		if s0 >= s1 {
+			return BoolValue(false), nil
+		}
+		s0 = s1
+	}
+	return BoolValue(true), nil
+}
+
 func (n *exprLT) Eval(params Params) (*Value, error) {
 	// Because of homogenisation during Parsing we know that all
 	// operands have the same type.
@@ -156,10 +178,10 @@ func (n *exprLT) Eval(params Params) (*Value, error) {
 		return n.integerLT(params)
 	case FLOAT:
 		return n.floatLT(params)
-		// case BOOL:
-		// 	return n.boolLT(params)
-		// case STRING:
-		// 	return n.stringLT(params)
+	// case BOOL:
+	// 	return n.boolLT(params)
+	case STRING:
+		return n.stringLT(params)
 	}
 	// This case should be unreachable if the parser is working correctly!
 	panic(fmt.Sprintf("subexpression evaluated to impossible type %q", t))

--- a/rule/eq_expr.go
+++ b/rule/eq_expr.go
@@ -2,12 +2,17 @@ package rule
 
 import (
 	"errors"
+	"fmt"
 )
 
 func init() {
 	Operators["eq"] = func() Operator { return newExprEq() }
 
 }
+
+/////////////////
+// Eq operator //
+/////////////////
 
 type exprEq struct {
 	operator
@@ -61,4 +66,79 @@ func (n *exprEq) Eval(params Params) (*Value, error) {
 	}
 
 	return BoolValue(true), nil
+}
+
+/////////////////
+// LT operator //
+/////////////////
+
+type exprLT struct {
+	operator
+}
+
+func newExprLT() *exprLT {
+	return &exprLT{
+		operator: operator{
+			contract: Contract{
+				OpCode:     "lt",
+				ReturnType: BOOLEAN,
+				Terms: []Term{
+					{
+						Type:        ANY,
+						Cardinality: MANY,
+						Min:         2,
+					},
+				},
+			},
+		},
+	}
+}
+
+// LT creates an expression that takes at least two operands and
+// evaluates to true if each successive operand has a lower value than
+// the next.
+func LT(vN ...Expr) Expr {
+	e := newExprLT()
+	e.consumeOperands(vN...)
+	return e
+}
+
+// perform a less-than comparison on a sequence of integers
+func (n *exprLT) integerLT(params Params) (*Value, error) {
+	var i0, i1 int64
+	var err error
+
+	i0, err = exprToInt64(n.operands[0], params)
+	if err != nil {
+		return nil, err
+	}
+	for j := 1; j < len(n.operands); j++ {
+		i1, err = exprToInt64(n.operands[j], params)
+		if err != nil {
+			return nil, err
+		}
+		if i0 >= i1 {
+			return BoolValue(false), nil
+		}
+		i0 = i1
+	}
+	return BoolValue(true), nil
+}
+
+func (n *exprLT) Eval(params Params) (*Value, error) {
+	// Because of homogenisation during Parsing we know that all
+	// operands have the same type.
+	t := n.operands[0].Contract().ReturnType
+	switch t {
+	case INTEGER:
+		return n.integerLT(params)
+		// case FLOAT:
+		// 	return n.floatLT(params)
+		// case BOOL:
+		// 	return n.boolLT(params)
+		// case STRING:
+		// 	return n.stringLT(params)
+	}
+	// This case should be unreachable if the parser is working correctly!
+	panic(fmt.Sprintf("subexpression evaluated to impossible type %q", t))
 }

--- a/rule/eq_expr.go
+++ b/rule/eq_expr.go
@@ -147,6 +147,36 @@ func (n *exprLT) floatLT(params Params) (*Value, error) {
 	return BoolValue(true), nil
 }
 
+// perform a less-than comparison on a sequence of bools
+func (n *exprLT) boolLT(params Params) (*Value, error) {
+	var b0, b1 bool
+	var err error
+
+	if len(n.operands) > 2 {
+		// We can't have greater than 2 operands and maintain
+		// an inequality with a binary choice.
+		return BoolValue(false), nil
+	}
+
+	b0, err = exprToBool(n.operands[0], params)
+	if err != nil {
+		return nil, err
+	}
+	if b0 {
+		// If b0 is True then it's not less than b1, and we can be done already.
+		return BoolValue(false), nil
+	}
+	b1, err = exprToBool(n.operands[1], params)
+	if err != nil {
+		return nil, err
+	}
+	if !b1 {
+		// If b1 is False then b0 can't be less than it..
+		return BoolValue(false), nil
+	}
+	return BoolValue(true), nil
+}
+
 // perform a less-than comparison on a sequence of strings
 func (n *exprLT) stringLT(params Params) (*Value, error) {
 	var s0, s1 string
@@ -178,8 +208,8 @@ func (n *exprLT) Eval(params Params) (*Value, error) {
 		return n.integerLT(params)
 	case FLOAT:
 		return n.floatLT(params)
-	// case BOOL:
-	// 	return n.boolLT(params)
+	case BOOLEAN:
+		return n.boolLT(params)
 	case STRING:
 		return n.stringLT(params)
 	}

--- a/rule/eq_expr.go
+++ b/rule/eq_expr.go
@@ -7,6 +7,7 @@ import (
 
 func init() {
 	Operators["eq"] = func() Operator { return newExprEq() }
+	Operators["lt"] = func() Operator { return newExprLT() }
 
 }
 

--- a/rule/eq_expr.go
+++ b/rule/eq_expr.go
@@ -125,6 +125,28 @@ func (n *exprLT) integerLT(params Params) (*Value, error) {
 	return BoolValue(true), nil
 }
 
+// perform a less-than comparison on a sequence of floats
+func (n *exprLT) floatLT(params Params) (*Value, error) {
+	var f0, f1 float64
+	var err error
+
+	f0, err = exprToFloat64(n.operands[0], params)
+	if err != nil {
+		return nil, err
+	}
+	for j := 1; j < len(n.operands); j++ {
+		f1, err = exprToFloat64(n.operands[j], params)
+		if err != nil {
+			return nil, err
+		}
+		if f0 >= f1 {
+			return BoolValue(false), nil
+		}
+		f0 = f1
+	}
+	return BoolValue(true), nil
+}
+
 func (n *exprLT) Eval(params Params) (*Value, error) {
 	// Because of homogenisation during Parsing we know that all
 	// operands have the same type.
@@ -132,8 +154,8 @@ func (n *exprLT) Eval(params Params) (*Value, error) {
 	switch t {
 	case INTEGER:
 		return n.integerLT(params)
-		// case FLOAT:
-		// 	return n.floatLT(params)
+	case FLOAT:
+		return n.floatLT(params)
 		// case BOOL:
 		// 	return n.boolLT(params)
 		// case STRING:

--- a/rule/eq_expr_test.go
+++ b/rule/eq_expr_test.go
@@ -82,6 +82,41 @@ func TestLT(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Float",
+			Cases: []testCase{
+				{
+					Name:     "2 value, < ∴ True",
+					Input:    []rule.Expr{rule.Float64Value(50.1), rule.Float64Value(50.2)},
+					Expected: true,
+				},
+				{
+					Name:     "3 value,< ∴ True",
+					Input:    []rule.Expr{rule.Float64Value(50.1), rule.Float64Value(50.2), rule.Float64Value(50.3)},
+					Expected: true,
+				},
+				{
+					Name:     "2 value, = ∴ False",
+					Input:    []rule.Expr{rule.Float64Value(50.1), rule.Float64Value(50.1)},
+					Expected: false,
+				},
+				{
+					Name:     "3 value, = ∴ False",
+					Input:    []rule.Expr{rule.Float64Value(50.1), rule.Float64Value(50.1), rule.Float64Value(50.1)},
+					Expected: false,
+				},
+				{
+					Name:     "2 value, > ∴ False",
+					Input:    []rule.Expr{rule.Float64Value(50.1), rule.Float64Value(50.1)},
+					Expected: false,
+				},
+				{
+					Name:     "3 value, > ∴ False",
+					Input:    []rule.Expr{rule.Float64Value(50.1), rule.Float64Value(50.1), rule.Float64Value(50.1)},
+					Expected: false,
+				},
+			},
+		},
 	}
 
 	for _, s := range ts {

--- a/rule/eq_expr_test.go
+++ b/rule/eq_expr_test.go
@@ -34,30 +34,66 @@ func TestEq(t *testing.T) {
 }
 
 func TestLT(t *testing.T) {
-	t.Run("Integer LessThan (True)", func(t *testing.T) {
-		lt := rule.LT(rule.Int64Value(50), rule.Int64Value(60))
-		val, err := lt.Eval(nil)
-		require.NoError(t, err)
-		require.True(t, val.Same(rule.BoolValue(true)))
-	})
-	t.Run("Integer LessThan Sequence(True)", func(t *testing.T) {
-		lt := rule.LT(rule.Int64Value(50), rule.Int64Value(60), rule.Int64Value(61))
-		val, err := lt.Eval(nil)
-		require.NoError(t, err)
-		require.True(t, val.Same(rule.BoolValue(true)))
-	})
 
-	t.Run("Integer LessThan (False)", func(t *testing.T) {
-		lt := rule.LT(rule.Int64Value(70), rule.Int64Value(60))
-		val, err := lt.Eval(nil)
-		require.NoError(t, err)
-		require.True(t, val.Same(rule.BoolValue(false)))
-	})
-	t.Run("Integer LessThan Sequence (False)", func(t *testing.T) {
-		lt := rule.LT(rule.Int64Value(70), rule.Int64Value(60), rule.Int64Value(50))
-		val, err := lt.Eval(nil)
-		require.NoError(t, err)
-		require.True(t, val.Same(rule.BoolValue(false)))
-	})
+	type testCase struct {
+		Name     string
+		Input    []rule.Expr
+		Expected bool
+	}
 
+	type typeSuite struct {
+		Name  string
+		Cases []testCase
+	}
+
+	ts := []typeSuite{
+		{
+			Name: "Integer",
+			Cases: []testCase{
+				{
+					Name:     "2 value, < ∴ True",
+					Input:    []rule.Expr{rule.Int64Value(50), rule.Int64Value(60)},
+					Expected: true,
+				},
+				{
+					Name:     "3 value,< ∴ True",
+					Input:    []rule.Expr{rule.Int64Value(50), rule.Int64Value(60), rule.Int64Value(70)},
+					Expected: true,
+				},
+				{
+					Name:     "2 value, = ∴ False",
+					Input:    []rule.Expr{rule.Int64Value(50), rule.Int64Value(50)},
+					Expected: false,
+				},
+				{
+					Name:     "3 value, = ∴ False",
+					Input:    []rule.Expr{rule.Int64Value(50), rule.Int64Value(50), rule.Int64Value(50)},
+					Expected: false,
+				},
+				{
+					Name:     "2 value, > ∴ False",
+					Input:    []rule.Expr{rule.Int64Value(50), rule.Int64Value(50)},
+					Expected: false,
+				},
+				{
+					Name:     "3 value, > ∴ False",
+					Input:    []rule.Expr{rule.Int64Value(50), rule.Int64Value(50), rule.Int64Value(50)},
+					Expected: false,
+				},
+			},
+		},
+	}
+
+	for _, s := range ts {
+		t.Run(s.Name, func(t *testing.T) {
+			for _, c := range s.Cases {
+				t.Run(c.Name, func(t *testing.T) {
+					lt := rule.LT(c.Input...)
+					val, err := lt.Eval(nil)
+					require.NoError(t, err)
+					require.True(t, val.Same(rule.BoolValue(c.Expected)))
+				})
+			}
+		})
+	}
 }

--- a/rule/eq_expr_test.go
+++ b/rule/eq_expr_test.go
@@ -117,6 +117,51 @@ func TestLT(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "String",
+			Cases: []testCase{
+				{
+					Name:     "Uppercase < Lowercase ∴ True",
+					Input:    []rule.Expr{rule.StringValue("A"), rule.StringValue("a")},
+					Expected: true,
+				},
+				{
+					Name:     "ASCIIbetical ∴ True",
+					Input:    []rule.Expr{rule.StringValue("0"), rule.StringValue("A")},
+					Expected: true,
+				},
+				{
+					Name:     "2 value, < ∴ True",
+					Input:    []rule.Expr{rule.StringValue("ABBA"), rule.StringValue("Beegees")},
+					Expected: true,
+				},
+				{
+					Name:     "3 value,< ∴ True",
+					Input:    []rule.Expr{rule.StringValue("ABBA"), rule.StringValue("Beegees"), rule.StringValue("Boney M")},
+					Expected: true,
+				},
+				{
+					Name:     "2 value, = ∴ False",
+					Input:    []rule.Expr{rule.StringValue("ABBA"), rule.StringValue("ABBA")},
+					Expected: false,
+				},
+				{
+					Name:     "3 value, = ∴ False",
+					Input:    []rule.Expr{rule.StringValue("ABBA"), rule.StringValue("ABBA"), rule.StringValue("ABBA")},
+					Expected: false,
+				},
+				{
+					Name:     "2 value, > ∴ False",
+					Input:    []rule.Expr{rule.StringValue("ABBA"), rule.StringValue("ABBA")},
+					Expected: false,
+				},
+				{
+					Name:     "3 value, > ∴ False",
+					Input:    []rule.Expr{rule.StringValue("ABBA"), rule.StringValue("ABBA"), rule.StringValue("ABBA")},
+					Expected: false,
+				},
+			},
+		},
 	}
 
 	for _, s := range ts {

--- a/rule/eq_expr_test.go
+++ b/rule/eq_expr_test.go
@@ -162,6 +162,31 @@ func TestLT(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Boolean",
+			Cases: []testCase{
+				{
+					Name:     "True = True ∴ False",
+					Input:    []rule.Expr{rule.BoolValue(true), rule.BoolValue(true)},
+					Expected: false,
+				},
+				{
+					Name:     "False = False ∴ False",
+					Input:    []rule.Expr{rule.BoolValue(false), rule.BoolValue(false)},
+					Expected: false,
+				},
+				{
+					Name:     "False < True ∴ True",
+					Input:    []rule.Expr{rule.BoolValue(false), rule.BoolValue(true)},
+					Expected: true,
+				},
+				{
+					Name:     "True > False ∴ False",
+					Input:    []rule.Expr{rule.BoolValue(true), rule.BoolValue(false)},
+					Expected: false,
+				},
+			},
+		},
 	}
 
 	for _, s := range ts {

--- a/rule/eq_expr_test.go
+++ b/rule/eq_expr_test.go
@@ -32,3 +32,32 @@ func TestEq(t *testing.T) {
 		require.Equal(t, rule.BoolValue(false), val)
 	})
 }
+
+func TestLT(t *testing.T) {
+	t.Run("Integer LessThan (True)", func(t *testing.T) {
+		lt := rule.LT(rule.Int64Value(50), rule.Int64Value(60))
+		val, err := lt.Eval(nil)
+		require.NoError(t, err)
+		require.True(t, val.Same(rule.BoolValue(true)))
+	})
+	t.Run("Integer LessThan Sequence(True)", func(t *testing.T) {
+		lt := rule.LT(rule.Int64Value(50), rule.Int64Value(60), rule.Int64Value(61))
+		val, err := lt.Eval(nil)
+		require.NoError(t, err)
+		require.True(t, val.Same(rule.BoolValue(true)))
+	})
+
+	t.Run("Integer LessThan (False)", func(t *testing.T) {
+		lt := rule.LT(rule.Int64Value(70), rule.Int64Value(60))
+		val, err := lt.Eval(nil)
+		require.NoError(t, err)
+		require.True(t, val.Same(rule.BoolValue(false)))
+	})
+	t.Run("Integer LessThan Sequence (False)", func(t *testing.T) {
+		lt := rule.LT(rule.Int64Value(70), rule.Int64Value(60), rule.Int64Value(50))
+		val, err := lt.Eval(nil)
+		require.NoError(t, err)
+		require.True(t, val.Same(rule.BoolValue(false)))
+	})
+
+}

--- a/rule/expr.go
+++ b/rule/expr.go
@@ -313,3 +313,13 @@ func exprToBool(e Expr, params Params) (bool, error) {
 	}
 	return b, nil
 }
+
+// exprToString returns the string value of an expression
+// evaluated with params.
+func exprToString(e Expr, params Params) (string, error) {
+	v, err := e.Eval(params)
+	if err != nil {
+		return "", err
+	}
+	return v.Data, nil
+}

--- a/rule/sexpr/assertions.lisp
+++ b/rule/sexpr/assertions.lisp
@@ -53,3 +53,15 @@
 (assert= 10 (let x (+ 5 5) x))          ; Let identifier equal result of value form
 (assert= #true (let f #false (not f)))  ; Operate on bound value
 
+;;;;;;;;;;;;;;;;;
+;; Comparitors ;;
+;;;;;;;;;;;;;;;;;
+(assert= #true (= 1 1)) ; Integer equality
+(assert= #false (= 1 2)) ; Integer inequality
+(assert= #true (= 1.1 1.1)) ; Float equality
+(assert= #false (= 1.1 1.2)) ; Float inequality
+(assert= #true (= "Foo" "Foo")) ; String equality
+(assert= #false (= "Foo" "foo")) ; String inequality (by case)
+(assert= #false (= "foo" "bar")) ; String inequality
+(assert= #true (= #true #true)) ; Boolean equality
+(assert= #false (= #true #false)) ; Boolean inequality

--- a/rule/sexpr/assertions.lisp
+++ b/rule/sexpr/assertions.lisp
@@ -53,15 +53,36 @@
 (assert= 10 (let x (+ 5 5) x))          ; Let identifier equal result of value form
 (assert= #true (let f #false (not f)))  ; Operate on bound value
 
-;;;;;;;;;;;;;;;;;
-;; Comparitors ;;
-;;;;;;;;;;;;;;;;;
-(assert= #true (= 1 1)) ; Integer equality
-(assert= #false (= 1 2)) ; Integer inequality
-(assert= #true (= 1.1 1.1)) ; Float equality
-(assert= #false (= 1.1 1.2)) ; Float inequality
-(assert= #true (= "Foo" "Foo")) ; String equality
-(assert= #false (= "Foo" "foo")) ; String inequality (by case)
-(assert= #false (= "foo" "bar")) ; String inequality
-(assert= #true (= #true #true)) ; Boolean equality
-(assert= #false (= #true #false)) ; Boolean inequality
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Equality and compasion ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(assert= #true (= 1 1))			; Integer equaliyt
+(assert= #false (= 1 2))		; Integer inequality
+(assert= #true (= 1.1 1.1))		; Float equality
+(assert= #false (= 1.1 1.2))		; Float inequality
+(assert= #true (= "Foo" "Foo"))		; String equality
+(assert= #false (= "Foo" "foo"))	; String inequality (by case)
+(assert= #false (= "foo" "bar"))	; String inequality
+(assert= #true (= #true #true))		; Boolean equality
+(assert= #false (= #true #false))	; Boolean inequality
+(assert= #true (< 0 1))			; integer less than (true)
+(assert= #false (< 0 0))		; integer less than (false because equal)
+(assert= #false (< 0 -1))		; integer less than (false because greater than)
+(assert= #true (< 0.1 0.2))		; integer less than (true)
+(assert= #false (< 0.1 0.1))		; integer less than (false because equal)
+(assert= #false (< 0.1 0))		; integer less than (false because greater than)
+(assert= #true (< "Abba" "BeeGees"))	; String less than (ASCIIbetical)
+(assert= #true (< "Eagle" "Eagles"))	; String less than (Length)
+(assert= #true (< "A" "a"))		; String less than (Case)
+(assert= #true (< "A" "a" "b"))		; Multi-string less than
+(assert= #false (< "A" "A"))		; Identical strings, therefore no inequality
+(assert= #false (< "AB" "A"))		; Second string is less than the first, therefore false
+(assert= #false (< "A" "a" "A"))        ; Multi-string false case (last string is >)
+(assert= #true (< #false #true))        ; Boolean, False < True = True
+(assert= #false (< #false #false))      ; Boolean, False < False = False
+(assert= #false (< #true #true))        ; Boolean, True < True = False
+(assert= #false (< #true #false))       ; Boolean, True < False = False
+
+
+
+


### PR DESCRIPTION
Partial fix for #27 

As per the spec, this implementation handles all fundatmental types - even though that's a little weird (what does it really mean to say that `#false` is  less that `#true`?)

Another point of discussion: equality is defined, per type, in `expr.go`, but I have put the per-type definitions here next to the operator definitions.  It would be a small matter to move them, but I thought I'd wait and have the chat about type coverage first. 