### PR TITLE
Allow the regula server to be run within dlv by calling 'make debug'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ testrace:
 run: build
 	regula -log-level debug -etcd-namespace regula-local -server-dist-path ./ui/app/dist
 
+debug:
+	dlv debug cmd/regula/main.go -- -log-level debug -etcd-namespace regula-local -server-dist-path ./ui/app/dist
+
 run-ui:
 	cd ./ui/app && yarn serve
 


### PR DESCRIPTION
A trivial PR to adgd a Makefile target that lets us run the server inside `dlv debug`. 

Personally I found this very useful. 