### PR TITLE
Convert params fix

### DIFF
--- a/ui/handler.go
+++ b/ui/handler.go
@@ -184,14 +184,20 @@ type newRulesetRequest struct {
 // newRulesetRequest, and returns an equivalent sexpr.Parameters map.
 func convertParams(input []param) (sexpr.Parameters, error) {
 	parm := make(sexpr.Parameters)
-	for _, p := range input {
-		for k, v := range p {
-			t, err := regrule.TypeFromName(v)
-			if err != nil {
-				return nil, err
-			}
-			parm[k] = t
+	for i, p := range input {
+		name, found := p["name"]
+		if !found {
+			return nil, fmt.Errorf("parameter %d has no name", i)
 		}
+		v, found := p["type"]
+		if !found {
+			return nil, fmt.Errorf("parameter %d (%s) has no type", i, name)
+		}
+		t, err := regrule.TypeFromName(v)
+		if err != nil {
+			return nil, err
+		}
+		parm[name] = t
 	}
 	return parm, nil
 }

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -181,6 +181,17 @@ func TestConvertParams(t *testing.T) {
 				"my-param": regrule.STRING,
 			},
 		},
+		{
+			name: "multiple parameters",
+			input: []param{
+				{"name": "p1", "type": "int64"},
+				{"name": "p2", "type": "float64"},
+			},
+			output: sexpr.Parameters{
+				"p1": regrule.INTEGER,
+				"p2": regrule.FLOAT,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/heetch/regula/mock"
+	regrule "github.com/heetch/regula/rule"
+	"github.com/heetch/regula/rule/sexpr"
 	"github.com/heetch/regula/store"
 	"github.com/stretchr/testify/require"
 )
@@ -142,4 +144,34 @@ func TestInternalHandler(t *testing.T) {
 			return nil, errors.New("some error")
 		}
 	})
+}
+
+func TestConvertParams(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   []param
+		output  sexpr.Parameters
+		errText string
+	}{
+		{
+			name:  "single int64",
+			input: []param{{"name": "my-param", "type": "int64"}},
+			output: sexpr.Parameters{
+				"my-param": regrule.INTEGER,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result, err := convertParams(c.input)
+			if c.errText != "" {
+				require.EqualError(t, err, c.errText)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.output, result)
+
+		})
+	}
 }

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -174,6 +174,13 @@ func TestConvertParams(t *testing.T) {
 				"my-param": regrule.BOOLEAN,
 			},
 		},
+		{
+			name:  "single string",
+			input: []param{{"name": "my-param", "type": "string"}},
+			output: sexpr.Parameters{
+				"my-param": regrule.STRING,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -32,7 +32,8 @@ func TestPOSTNewRulesetWithParserError(t *testing.T) {
     "signature": {
         "params": [
             {
-                "foo": "string"
+                "name": "foo",
+                "type": "string"
             }
         ],
         "returnType": "string"
@@ -72,7 +73,8 @@ func TestPOSTNewRuleset(t *testing.T) {
     "signature": {
         "params": [
             {
-                "foo": "string"
+                "name": "foo",
+                "type": "string"
             }
         ],
         "returnType": "string"

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -160,6 +160,13 @@ func TestConvertParams(t *testing.T) {
 				"my-param": regrule.INTEGER,
 			},
 		},
+		{
+			name:  "single float64",
+			input: []param{{"name": "my-param", "type": "float64"}},
+			output: sexpr.Parameters{
+				"my-param": regrule.FLOAT,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -192,6 +192,16 @@ func TestConvertParams(t *testing.T) {
 				"p2": regrule.FLOAT,
 			},
 		},
+		{
+			name:    "no name error",
+			input:   []param{{"type": "int64"}},
+			errText: "parameter 0 has no name",
+		},
+		{
+			name:    "no type error",
+			input:   []param{{"name": "foo"}},
+			errText: "parameter 0 (foo) has no type",
+		},
 	}
 
 	for _, c := range cases {

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -167,6 +167,13 @@ func TestConvertParams(t *testing.T) {
 				"my-param": regrule.FLOAT,
 			},
 		},
+		{
+			name:  "single bool",
+			input: []param{{"name": "my-param", "type": "bool"}},
+			output: sexpr.Parameters{
+				"my-param": regrule.BOOLEAN,
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Fixes #70 

This PR addresses a false assumption in the design of the `ui.handler.convertParams` function.
Prior to this branch the code assumed that parameter specifications coming from the UI look like this:

```
{"my-parameter: "int64"}
```

... but they actually look like this:

```
{"name": "my-parameter",
 "type": "int64"}
```

This PR adds tests and modifies the code to reflect this. 