### PR TITLE
Fix "in" signature

### DIFF
--- a/rule/set_expr.go
+++ b/rule/set_expr.go
@@ -21,12 +21,8 @@ func newExprIn() *exprIn {
 				Terms: []Term{
 					{
 						Type:        ANY,
-						Cardinality: ONE,
-					},
-					{
-						Type:        ANY,
 						Cardinality: MANY,
-						Min:         1,
+						Min:         2,
 					},
 				},
 			},


### PR DESCRIPTION
The `in` operator has a signature that allows its first parameter to be a different type to the rest of the parameters.  This is pointless, it's better to run the paramteres through the homogonisaton process.  Change the signature to make that happen. 