### PR TITLE
Fix evaluation URL generated by client

### DIFF
--- a/api/client/rulesets.go
+++ b/api/client/rulesets.go
@@ -71,7 +71,7 @@ func (s *RulesetService) EvalVersion(ctx context.Context, path, version string, 
 	}
 
 	q := req.URL.Query()
-	q.Add("eval", "")
+	q.Add("eval", "true")
 	for _, k := range params.Keys() {
 		v, err := params.EncodeValue(k)
 		if err != nil {


### PR DESCRIPTION
Simple one line fix that stops us producing a URL like this when running `get` in the client:

`http://localhost:5331/ruleset/butter?eval=&selector=1`

.. but instead create one like this:

`http://localhost:5331/ruleset/butter?eval&selector=1`