### PR TITLE
Float to int

### DIFF
--- a/rule/cast_expr.go
+++ b/rule/cast_expr.go
@@ -6,7 +6,12 @@ import (
 
 func init() {
 	Operators["intToFloat"] = func() Operator { return newExprIntToFloat() }
+	Operators["floatToInt"] = func() Operator { return newExprFloatToInt() }
 }
+
+/////////////////////////
+// IntToFloat Operator //
+/////////////////////////
 
 // exprIntToFloat is an operation that converts an Int64 type to a Float64 type.
 type exprIntToFloat struct {
@@ -50,4 +55,53 @@ func (n *exprIntToFloat) Eval(params Params) (*Value, error) {
 		return nil, err
 	}
 	return Float64Value(float64(iVal)), nil
+}
+
+/////////////////////////
+// FloatToInt Operator //
+/////////////////////////
+
+// exprFloatToInt is an operation that converts a Float64 type to an Int64 type.
+type exprFloatToInt struct {
+	operator
+}
+
+// newExprFloatToInt returns a pointer to a exprFloatToInt operator, initialised with a Contract.
+func newExprFloatToInt() *exprFloatToInt {
+	return &exprFloatToInt{
+		operator: operator{
+			contract: Contract{
+				OpCode:     "floatToInt",
+				ReturnType: INTEGER,
+				Terms: []Term{
+					{
+						Cardinality: ONE,
+						Type:        FLOAT,
+					},
+				},
+			},
+		},
+	}
+}
+
+// FloatToInt is an operator that converts as Float64 into an Int64 type.
+func FloatToInt(vN ...Expr) Expr {
+	e := newExprFloatToInt()
+	e.consumeOperands(vN...)
+	return e
+}
+
+// Eval will convert the operand provided to exprFloatToInt to an Int64Value.  Eval makes exprFloatToInt implement the Expr interface.
+func (n *exprFloatToInt) Eval(params Params) (*Value, error) {
+	op := n.operands[0]
+	val, err := op.Eval(params)
+	if err != nil {
+		return nil, err
+	}
+	// Handily this will just give us the int we want ;-)
+	fVal, err := strconv.ParseFloat(val.Data, 64)
+	if err != nil {
+		return nil, err
+	}
+	return Int64Value(int64(fVal)), nil
 }

--- a/rule/cast_expr.go
+++ b/rule/cast_expr.go
@@ -84,7 +84,7 @@ func newExprFloatToInt() *exprFloatToInt {
 	}
 }
 
-// FloatToInt is an operator that converts as Float64 into an Int64 type.
+// FloatToInt is an operator that converts a Float64 into an Int64 type.
 func FloatToInt(vN ...Expr) Expr {
 	e := newExprFloatToInt()
 	e.consumeOperands(vN...)

--- a/rule/cast_expr.go
+++ b/rule/cast_expr.go
@@ -37,9 +37,9 @@ func newExprIntToFloat() *exprIntToFloat {
 }
 
 // IntToFloat is an operator that converts as Float64 into an Int64 type.
-func IntToFloat(vN ...Expr) Expr {
+func IntToFloat(v Expr) Expr {
 	e := newExprIntToFloat()
-	e.consumeOperands(vN...)
+	e.consumeOperands(v)
 	return e
 }
 
@@ -85,9 +85,9 @@ func newExprFloatToInt() *exprFloatToInt {
 }
 
 // FloatToInt is an operator that converts a Float64 into an Int64 type.
-func FloatToInt(vN ...Expr) Expr {
+func FloatToInt(v Expr) Expr {
 	e := newExprFloatToInt()
-	e.consumeOperands(vN...)
+	e.consumeOperands(v)
 	return e
 }
 

--- a/rule/cast_expr_test.go
+++ b/rule/cast_expr_test.go
@@ -13,3 +13,10 @@ func TestIntToFloat(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, rule.Float64Value(1.0), f)
 }
+
+func TestFloatToInt(t *testing.T) {
+	cast := rule.FloatToInt(rule.Float64Value(1.5))
+	i, err := cast.Eval(nil)
+	require.NoError(t, err)
+	require.Equal(t, rule.Int64Value(1), i)
+}

--- a/rule/cast_expr_test.go
+++ b/rule/cast_expr_test.go
@@ -1,0 +1,15 @@
+package rule_test
+
+import (
+	"testing"
+
+	"github.com/heetch/regula/rule"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntToFloat(t *testing.T) {
+	cast := rule.IntToFloat(rule.Int64Value(1))
+	f, err := cast.Eval(nil)
+	require.NoError(t, err)
+	require.Equal(t, rule.Float64Value(1.0), f)
+}

--- a/rule/sexpr/assertions.lisp
+++ b/rule/sexpr/assertions.lisp
@@ -44,6 +44,8 @@
 ;;;;;;;;;;;;;;;;;;;;;
 (assert= 1.0 (int->float 1))		; Cast positive integer to float
 (assert= -12.0 (int->float -12))	; Cast negative integer to float
+(assert= 1 (float->int 1.5))		; Cast a positive float to an integer
+(assert= -13 (float->int -13.3939))	; Cast a negative float to an integer
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;

--- a/rule/sexpr/parser.go
+++ b/rule/sexpr/parser.go
@@ -31,6 +31,7 @@ func makeSymbolMap() *opCodeMap {
 	sm.mapSymbol("hash", "hash")
 	sm.mapSymbol("percentile", "percentile")
 	sm.mapSymbol("int->float", "intToFloat")
+	sm.mapSymbol("float->int", "floatToInt")
 	sm.mapSymbol("let", "let")
 	sm.mapSymbol("if", "if")
 	return sm


### PR DESCRIPTION
Fixes #82 

This PR introduces the `float->int` operator, and along the way adds a missing test for `int->float`. 