### PR TITLE
Pretty print rules as RUSE syntax

### DIFF
--- a/rule/sexpr/print.go
+++ b/rule/sexpr/print.go
@@ -1,17 +1,129 @@
 package sexpr
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/heetch/regula/rule"
 )
 
-func Print(e rule.Expr) (string, error) {
+var sm *opCodeMap
+
+func init() {
+	sm = makeSymbolMap()
+}
+
+// prettyPrintOp is the generic printer for operations
+func prettyPrintOp(indent, wrap int, e rule.Expr) (string, error) {
+	output := ""
+	v, ok := e.(rule.Operator)
+	if !ok {
+		return "", fmt.Errorf("called prettyPrintOp with non-operator expression")
+	}
+	symbol, err := sm.getSymbolForOpCode(v.Contract().OpCode)
+	if err != nil {
+		return "", err
+	}
+	prefix := "(" + symbol
+	subdent := indent + len(prefix)
+	currentIndent := subdent
+	leader := strings.Repeat(" ", subdent)
+	output += prefix
+	ops := v.Operands()
+	for _, op := range ops {
+		unindented, err := PrettyPrint(0, wrap, op)
+		if err != nil {
+			return "", err
+		}
+		parts := strings.Split(unindented, "\n")
+		if (currentIndent + 1 + len(parts[0])) >= wrap {
+			output += "\n" + leader
+			currentIndent = subdent
+		}
+		indented, err := PrettyPrint(currentIndent+1, wrap, op)
+		if err != nil {
+			return "", err
+		}
+		parts = strings.Split(indented, "\n")
+		if len(parts) > 1 {
+			output += " " + indented
+			currentIndent = len(parts[len(parts)-1])
+		} else {
+			output += " " + indented
+			currentIndent = currentIndent + 1 + len(parts[0])
+		}
+	}
+	output += ")"
+	return output, nil
+}
+
+// prettyPrintLet is a special case printer for let forms.  The intent is to force lets to conform to the form:
+//
+//    (let symbol value
+//         (body ...))
+//
+func prettyPrintLet(indent, wrap int, e rule.Expr) (string, error) {
+	v, ok := e.(rule.Operator)
+	if !ok || v.Contract().OpCode != "let" {
+		return "", fmt.Errorf("called prettyPrintLet without a let expression")
+	}
+	ops := v.Operands()
+	subdent := indent + 5 // 5 = len("(let ")
+	subleader := strings.Repeat(" ", subdent)
+	symbol, err := PrettyPrint(subdent, wrap, ops[0])
+	if err != nil {
+		return "", err
+	}
+	value, err := PrettyPrint(subdent+1+len(symbol), wrap, ops[1])
+	if err != nil {
+		return "", err
+	}
+	body, err := PrettyPrint(subdent, wrap, ops[2])
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("(let %s %s\n%s%s)", symbol, value, subleader, body), nil
+}
+
+// prettyPrintIf is the special case printer for if forms.  The intent is that if forms should always print with the following outline:
+//
+//    (if (test)
+//        (true-body)
+//        (false-body))
+//
+func prettyPrintIf(indent, wrap int, e rule.Expr) (string, error) {
+	v, ok := e.(rule.Operator)
+	if !ok || v.Contract().OpCode != "if" {
+		return "", fmt.Errorf("called prettyPrintIf without and if expression")
+	}
+	ops := v.Operands()
+	subdent := indent + 4 // 4 = len("(if ")
+	subleader := strings.Repeat(" ", subdent)
+	test, err := PrettyPrint(subdent, wrap, ops[0])
+	if err != nil {
+		return "", err
+	}
+	truePart, err := PrettyPrint(subdent, wrap, ops[1])
+	if err != nil {
+		return "", err
+	}
+	falsePart, err := PrettyPrint(subdent, wrap, ops[2])
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("(if %s\n%s%s\n%s%s)", test, subleader, truePart, subleader, falsePart), nil
+}
+
+// PrettyPrint takes a tree of expressions and prints them out as a well-formatted RUSE program.
+func PrettyPrint(indent, wrap int, e rule.Expr) (string, error) {
+	var line string
+	var err error
 	switch v := e.(type) {
 	case *rule.Value:
 		switch v.Type {
 		case "int64":
-			return v.Data, nil
+			line = v.Data
 		case "float64":
 			// For simplicity we used a fixed precision
 			// representation internally, but that might
@@ -21,10 +133,32 @@ func Print(e rule.Expr) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			return strconv.FormatFloat(f, 'f', -1, 64), nil
+			line = strconv.FormatFloat(f, 'f', -1, 64)
 		case "bool":
-			return "#" + v.Data, nil
+			line = "#" + v.Data
+		case "string":
+			line = fmt.Sprintf("%q", v.Data)
+		}
+	case *rule.Param:
+		line = v.Name
+	case rule.Operator:
+		switch v.Contract().OpCode {
+		case "if":
+			line, err = prettyPrintIf(indent, wrap, e)
+			if err != nil {
+				return "", err
+			}
+		case "let":
+			line, err = prettyPrintLet(indent, wrap, e)
+			if err != nil {
+				return "", err
+			}
+		default:
+			line, err = prettyPrintOp(indent, wrap, e)
+			if err != nil {
+				return "", err
+			}
 		}
 	}
-	return "", nil
+	return line, nil
 }

--- a/rule/sexpr/print.go
+++ b/rule/sexpr/print.go
@@ -1,0 +1,14 @@
+package sexpr
+
+import "github.com/heetch/regula/rule"
+
+func Print(e rule.Expr) string {
+	switch v := e.(type) {
+	case *rule.Value:
+		switch v.Type {
+		case "int64", "foat64":
+			return v.Data
+		}
+	}
+	return ""
+}

--- a/rule/sexpr/print.go
+++ b/rule/sexpr/print.go
@@ -22,6 +22,8 @@ func Print(e rule.Expr) (string, error) {
 				return "", err
 			}
 			return strconv.FormatFloat(f, 'f', -1, 64), nil
+		case "bool":
+			return "#" + v.Data, nil
 		}
 	}
 	return "", nil

--- a/rule/sexpr/print.go
+++ b/rule/sexpr/print.go
@@ -1,14 +1,28 @@
 package sexpr
 
-import "github.com/heetch/regula/rule"
+import (
+	"strconv"
 
-func Print(e rule.Expr) string {
+	"github.com/heetch/regula/rule"
+)
+
+func Print(e rule.Expr) (string, error) {
 	switch v := e.(type) {
 	case *rule.Value:
 		switch v.Type {
-		case "int64", "foat64":
-			return v.Data
+		case "int64":
+			return v.Data, nil
+		case "float64":
+			// For simplicity we used a fixed precision
+			// representation internally, but that might
+			// pack trailing zeros into its output, so we
+			// go back via a real float64 for printing.
+			f, err := strconv.ParseFloat(v.Data, 64)
+			if err != nil {
+				return "", err
+			}
+			return strconv.FormatFloat(f, 'f', -1, 64), nil
 		}
 	}
-	return ""
+	return "", nil
 }

--- a/rule/sexpr/print_test.go
+++ b/rule/sexpr/print_test.go
@@ -8,7 +8,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrint(t *testing.T) {
+func TestPrettyPrintLet(t *testing.T) {
+	e := rule.Let(rule.Int64Param("x"), rule.Int64Value(1), rule.Eq(rule.Int64Param("x"), rule.Int64Value(1)))
+	result, err := sexpr.PrettyPrint(0, 79, e)
+	require.NoError(t, err)
+	require.Equal(t, "(let x 1\n     (= x 1))", result)
+}
+
+func TestPrettyPrintLetAsSubexpression(t *testing.T) {
+	e := rule.Eq(rule.BoolValue(true), rule.Let(rule.Int64Param("x"), rule.Int64Value(1), rule.Eq(rule.Int64Param("x"), rule.Int64Value(1))))
+	result, err := sexpr.PrettyPrint(0, 79, e)
+	require.NoError(t, err)
+	require.Equal(t, "(= #true (let x 1\n              (= x 1)))", result)
+}
+
+func TestPrettyPrintIf(t *testing.T) {
+	e := rule.If(rule.Eq(rule.Int64Value(1), rule.Int64Value(2)), rule.StringValue("Yes"), rule.StringValue("No"))
+	result, err := sexpr.PrettyPrint(0, 79, e)
+	require.NoError(t, err)
+	require.Equal(t, "(if (= 1 2)\n    \"Yes\"\n    \"No\")", result)
+}
+
+func TestPrettyPrintWithSingleLevelWrap(t *testing.T) {
+	e := rule.Eq(rule.Int64Value(99), rule.Int64Value(99))
+	result, err := sexpr.PrettyPrint(0, 7, e)
+	require.NoError(t, err)
+	require.Equal(t, "(= 99\n   99)", result)
+}
+
+func TestPrettyPrintWithWrapping(t *testing.T) {
+	e := rule.Eq(rule.Div(rule.Int64Value(99), rule.Add(rule.Float64Value(23.22), rule.Int64Value(3))), rule.Float64Value(77.77))
+	result, err := sexpr.PrettyPrint(0, 30, e)
+	require.NoError(t, err)
+	require.Equal(t, "(= (/ (int->float 99)\n      (+ 23.22 (int->float 3)))\n   77.77)", result)
+}
+
+func TestPrettyPrint(t *testing.T) {
 	cases := []struct {
 		name     string
 		input    rule.Expr
@@ -44,10 +79,31 @@ func TestPrint(t *testing.T) {
 			input:    rule.BoolValue(false),
 			expected: "#false",
 		},
+		{
+			name:     "String",
+			input:    rule.StringValue("foo"),
+			expected: `"foo"`,
+		},
+		{
+			// All parameters are just names when we print them.
+			name:     "Parameter",
+			input:    rule.StringParam("wibble"),
+			expected: "wibble",
+		},
+		{
+			name:     "Simple expression",
+			input:    rule.Add(rule.Int64Value(10), rule.Int64Value(20)),
+			expected: "(+ 10 20)",
+		},
+		{
+			name:     "Complex expression",
+			input:    rule.Eq(rule.Div(rule.Int64Value(99), rule.Add(rule.Float64Value(23.22), rule.Int64Value(3))), rule.Float64Value(77.77)),
+			expected: `(= (/ (int->float 99) (+ 23.22 (int->float 3))) 77.77)`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result, err := sexpr.Print(c.input)
+			result, err := sexpr.PrettyPrint(0, 79, c.input)
 			require.NoError(t, err)
 			require.Equal(t, c.expected, result)
 		})

--- a/rule/sexpr/print_test.go
+++ b/rule/sexpr/print_test.go
@@ -29,6 +29,11 @@ func TestPrint(t *testing.T) {
 			input:    rule.Float64Value(72.8987),
 			expected: "72.8987",
 		},
+		{
+			name:     "Negative Float64Value",
+			input:    rule.Float64Value(-72.8987),
+			expected: "-72.8987",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/rule/sexpr/print_test.go
+++ b/rule/sexpr/print_test.go
@@ -1,0 +1,29 @@
+package sexpr_test
+
+import (
+	"testing"
+
+	"github.com/heetch/regula/rule"
+	"github.com/heetch/regula/rule/sexpr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrint(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    rule.Expr
+		expected string
+	}{
+		{
+			name:     "Int64Value",
+			input:    rule.Int64Value(590),
+			expected: "590",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := sexpr.Print(c.input)
+			require.Equal(t, c.expected, result)
+		})
+	}
+}

--- a/rule/sexpr/print_test.go
+++ b/rule/sexpr/print_test.go
@@ -19,10 +19,21 @@ func TestPrint(t *testing.T) {
 			input:    rule.Int64Value(590),
 			expected: "590",
 		},
+		{
+			name:     "Negative Int64Value",
+			input:    rule.Int64Value(-590),
+			expected: "-590",
+		},
+		{
+			name:     "Float64Value",
+			input:    rule.Float64Value(72.8987),
+			expected: "72.8987",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result := sexpr.Print(c.input)
+			result, err := sexpr.Print(c.input)
+			require.NoError(t, err)
 			require.Equal(t, c.expected, result)
 		})
 	}

--- a/rule/sexpr/print_test.go
+++ b/rule/sexpr/print_test.go
@@ -34,6 +34,16 @@ func TestPrint(t *testing.T) {
 			input:    rule.Float64Value(-72.8987),
 			expected: "-72.8987",
 		},
+		{
+			name:     "Boolean (true)",
+			input:    rule.BoolValue(true),
+			expected: "#true",
+		},
+		{
+			name:     "Boolean (false)",
+			input:    rule.BoolValue(false),
+			expected: "#false",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes issue #84 and is a prerequisite of all UI work displaying existing rules.
Implent the `PrettyPrint` function for regula expressions, essentially dumping them back as a rigidly formatted RUSE syntax.

Note that we handle `let` and `if` forms differently from other operators.  

Pretty printing is a complex and annoying thing, so please point out anywhere this code needs to be better documented. 
