### PR TITLE
Simplify evaluator

### DIFF
--- a/api/client/rulesets.go
+++ b/api/client/rulesets.go
@@ -58,13 +58,7 @@ func (s *RulesetService) List(ctx context.Context, prefix string, opt *ListOptio
 
 // Eval evaluates the given ruleset with the given params.
 // It implements the regula.Evaluator interface and thus can be passed to the regula.Engine.
-func (s *RulesetService) Eval(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error) {
-	return s.EvalVersion(ctx, path, "", params)
-}
-
-// EvalVersion evaluates the given ruleset version with the given params.
-// It implements the regula.Evaluator interface and thus can be passed to the regula.Engine.
-func (s *RulesetService) EvalVersion(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error) {
+func (s *RulesetService) Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error) {
 	req, err := s.client.newRequest("GET", s.joinPath(path), nil)
 	if err != nil {
 		return nil, err

--- a/api/client/rulesets_test.go
+++ b/api/client/rulesets_test.go
@@ -78,26 +78,7 @@ func ExampleRulesetService_Eval() {
 		log.Fatal(err)
 	}
 
-	resp, err := c.Rulesets.Eval(context.Background(), "path/to/ruleset", regula.Params{
-		"foo": "bar",
-		"baz": int64(42),
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println(resp.Value.Data)
-	fmt.Println(resp.Value.Type)
-	fmt.Println(resp.Version)
-}
-
-func ExampleRulesetService_EvalVersion() {
-	c, err := client.New("http://127.0.0.1:5331")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	resp, err := c.Rulesets.EvalVersion(context.Background(), "path/to/ruleset", "xyzabc", regula.Params{
+	resp, err := c.Rulesets.Eval(context.Background(), "path/to/ruleset", "version", regula.Params{
 		"foo": "bar",
 		"baz": int64(42),
 	})
@@ -257,7 +238,7 @@ func TestRulesetService(t *testing.T) {
 
 		exp := regula.EvalResult{Value: rule.StringValue("baz"), Version: "1234"}
 
-		resp, err := cli.Rulesets.Eval(context.Background(), "path/to/ruleset", regula.Params{
+		resp, err := cli.Rulesets.Eval(context.Background(), "path/to/ruleset", "", regula.Params{
 			"foo": "bar",
 		})
 		require.NoError(t, err)

--- a/engine.go
+++ b/engine.go
@@ -276,24 +276,3 @@ func (b *RulesetBuffer) getVersion(path, version string) (*rulesetInfo, error) {
 
 	return nil, rerrors.ErrRulesetNotFound
 }
-
-// EvalVersion evaluates the selected ruleset version or returns rerrors.ErrRulesetNotFound if not found.
-func (b *RulesetBuffer) EvalVersion(ctx context.Context, path, version string, params rule.Params) (*EvalResult, error) {
-	b.rw.RLock()
-	defer b.rw.RUnlock()
-
-	ri, err := b.getVersion(path, version)
-	if err != nil {
-		return nil, err
-	}
-
-	v, err := ri.r.Eval(params)
-	if err != nil {
-		return nil, err
-	}
-
-	return &EvalResult{
-		Value:   v,
-		Version: ri.version,
-	}, nil
-}

--- a/engine.go
+++ b/engine.go
@@ -139,15 +139,13 @@ func Version(version string) Option {
 	}
 }
 
-// An Evaluator provides methods to evaluate rulesets from any location.
+// An Evaluator provides a method to evaluate rulesets from any location.
 // Long running implementations must listen to the given context for timeout and cancelation.
 type Evaluator interface {
-	// Eval evaluates a ruleset using the given params.
-	// If no ruleset is found for a given path, the implementation must return rerrors.ErrRulesetNotFound.
-	Eval(ctx context.Context, path string, params rule.Params) (*EvalResult, error)
-	// EvalVersion evaluates a specific version of a ruleset using the given params.
-	// If no ruleset is found for a given path, the implementation must return rerrors.ErrRulesetNotFound.
-	EvalVersion(ctx context.Context, path string, version string, params rule.Params) (*EvalResult, error)
+	// Eval evaluates a ruleset using the given params. If the version is not empty, the selected version
+	// will be used for evaluation. If it's empty, the latest version will be used.
+	// If no ruleset is found for a given path, the implementation must return errors.ErrRulesetNotFound.
+	Eval(ctx context.Context, path string, version string, params rule.Params) (*EvalResult, error)
 }
 
 // EvalResult is the product of an evaluation. It contains the value generated as long as some metadata.

--- a/engine.go
+++ b/engine.go
@@ -34,16 +34,7 @@ func (e *Engine) get(ctx context.Context, typ, path string, params rule.Params, 
 		opt(&cfg)
 	}
 
-	var (
-		result *EvalResult
-		err    error
-	)
-
-	if cfg.Version != "" {
-		result, err = e.evaluator.EvalVersion(ctx, path, cfg.Version, params)
-	} else {
-		result, err = e.evaluator.Eval(ctx, path, params)
-	}
+	result, err := e.evaluator.Eval(ctx, path, cfg.Version, params)
 	if err != nil {
 		if err == rerrors.ErrRulesetNotFound || err == rerrors.ErrNoMatch {
 			return nil, err
@@ -107,7 +98,7 @@ func (e *Engine) GetFloat64(ctx context.Context, path string, params rule.Params
 // tagged with the "ruleset" struct tag.
 func (e *Engine) LoadStruct(ctx context.Context, to interface{}, params rule.Params) error {
 	b := backend.Func("regula", func(ctx context.Context, path string) ([]byte, error) {
-		res, err := e.evaluator.Eval(ctx, path, params)
+		res, err := e.evaluator.Eval(ctx, path, "", params)
 		if err != nil {
 			if err == rerrors.ErrRulesetNotFound {
 				return nil, backend.ErrNotFound

--- a/mock/store.go
+++ b/mock/store.go
@@ -13,20 +13,18 @@ var _ store.RulesetService = new(RulesetService)
 
 // RulesetService mocks the store.RulesetService interface.
 type RulesetService struct {
-	CreateCount      int
-	CreateFn         func(ctx context.Context, path string, signature *regula.Signature) error
-	GetCount         int
-	GetFn            func(ctx context.Context, path, version string) (*store.RulesetEntry, error)
-	ListCount        int
-	ListFn           func(context.Context, string, *store.ListOptions) (*store.RulesetEntries, error)
-	WatchCount       int
-	WatchFn          func(context.Context, string, string) (*store.RulesetEvents, error)
-	PutCount         int
-	PutFn            func(context.Context, string) (*store.RulesetEntry, error)
-	EvalCount        int
-	EvalFn           func(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error)
-	EvalVersionCount int
-	EvalVersionFn    func(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
+	CreateCount int
+	CreateFn    func(ctx context.Context, path string, signature *regula.Signature) error
+	GetCount    int
+	GetFn       func(ctx context.Context, path, version string) (*store.RulesetEntry, error)
+	ListCount   int
+	ListFn      func(context.Context, string, *store.ListOptions) (*store.RulesetEntries, error)
+	WatchCount  int
+	WatchFn     func(context.Context, string, string) (*store.RulesetEvents, error)
+	PutCount    int
+	PutFn       func(context.Context, string) (*store.RulesetEntry, error)
+	EvalCount   int
+	EvalFn      func(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
 }
 
 // Create runs CreateFn if provided and increments CreateCount when invoked.
@@ -84,21 +82,11 @@ func (s *RulesetService) Put(ctx context.Context, path string, ruleset *regula.R
 }
 
 // Eval runs EvalFn if provided and increments EvalCount when invoked.
-func (s *RulesetService) Eval(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error) {
+func (s *RulesetService) Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error) {
 	s.EvalCount++
 
 	if s.EvalFn != nil {
-		return s.EvalFn(ctx, path, params)
-	}
-	return nil, nil
-}
-
-// EvalVersion runs EvalVersionFn if provided and increments EvalVersionCount when invoked.
-func (s *RulesetService) EvalVersion(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error) {
-	s.EvalVersionCount++
-
-	if s.EvalVersionFn != nil {
-		return s.EvalVersionFn(ctx, path, version, params)
+		return s.EvalFn(ctx, path, version, params)
 	}
 	return nil, nil
 }

--- a/store/etcd/eval.go
+++ b/store/etcd/eval.go
@@ -13,12 +13,7 @@ import (
 )
 
 // Eval evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
-func (s *RulesetService) Eval(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error) {
-	return s.EvalVersion(ctx, path, "", params)
-}
-
-// EvalVersion evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
-func (s *RulesetService) EvalVersion(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error) {
+func (s *RulesetService) Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error) {
 	var res *clientv3.GetResponse
 	var err error
 

--- a/store/service.go
+++ b/store/service.go
@@ -33,9 +33,7 @@ type RulesetService interface {
 	// Watch a prefix for changes and return a list of events.
 	Watch(ctx context.Context, prefix string, revision string) (*RulesetEvents, error)
 	// Eval evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
-	Eval(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error)
-	// EvalVersion evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
-	EvalVersion(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
+	Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
 }
 
 // ListOptions contains list options.


### PR DESCRIPTION
This PR simplifies the `regula.Evaluator` interface:

Before:
```go
type Evaluator interface {
    Eval(ctx context.Context, path string, params rule.Params) (*EvalResult, error)
    EvalVersion(ctx context.Context, path string, version string, params rule.Params) (*EvalResult, error)
}
```

After:
```go
type Evaluator interface {
    Eval(ctx context.Context, path, version string, params rule.Params) (*EvalResult, error)
}
```