### PR TITLE
Add FNV and Percentile operators, and testing

### DIFF
--- a/rule/expr.go
+++ b/rule/expr.go
@@ -288,7 +288,7 @@ type exprFNV struct {
 func FNV(v Expr) Expr {
 	return &exprFNV{
 		operator: operator{
-			kind:     "FNV",
+			kind:     "fnv",
 			operands: []Expr{v},
 		},
 	}

--- a/rule/expr_test.go
+++ b/rule/expr_test.go
@@ -195,6 +195,7 @@ func TestIn(t *testing.T) {
 	})
 }
 
+
 func TestGt(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -267,6 +268,67 @@ func TestGt(t *testing.T) {
 		})
 	}
 }
+
+func TestFNV(t *testing.T) {
+	cases := []struct {
+		name   string
+		val    rule.Expr
+		result int64
+	}{
+		{
+			name:   "Int64Value",
+			val:    rule.Int64Value(1234),
+			result: 2179869525,
+		},
+		{
+			name:   "Float64Value",
+			val:    rule.Float64Value(1234.1234),
+			result: 566939793,
+		},
+		{
+			name:   "StringValue",
+			val:    rule.StringValue("travelling in style"),
+			result: 536463009,
+		},
+		{
+			name:   "BoolValue (true)",
+			val:    rule.BoolValue(true),
+			result: 3053630529,
+		},
+		{
+			name:   "BoolValue (false)",
+			val:    rule.BoolValue(false),
+			result: 2452206122,
+		},
+	}
+	params := regula.Params{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hash := rule.FNV(tc.val)
+			result, err := hash.Eval(params)
+			require.NoError(t, err)
+			require.Equal(t, rule.Int64Value(tc.result), result)
+		})
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	// "Bob Dylan" is in the 56th percentile, so this is true
+	v1 := rule.StringValue("Bob Dylan")
+	p := rule.Int64Value(96)
+	perc := rule.Percentile(v1, p)
+	res, err := perc.Eval(nil)
+	require.NoError(t, err)
+	require.Equal(t, rule.BoolValue(true), res)
+
+	// "Joni Mitchell" is in the 97th percentile, so this is false
+	v2 := rule.StringValue("Joni Mitchell")
+	perc = rule.Percentile(v2, p)
+	res, err = perc.Eval(nil)
+	require.NoError(t, err)
+	require.Equal(t, rule.BoolValue(false), res)
+}
+
 
 func TestParam(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {

--- a/rule/expr_test.go
+++ b/rule/expr_test.go
@@ -313,7 +313,7 @@ func TestFNV(t *testing.T) {
 }
 
 func TestPercentile(t *testing.T) {
-	// "Bob Dylan" is in the 56th percentile, so this is true
+	// "Bob Dylan" is in the 96th percentile, so this is true
 	v1 := rule.StringValue("Bob Dylan")
 	p := rule.Int64Value(96)
 	perc := rule.Percentile(v1, p)

--- a/rule/json.go
+++ b/rule/json.go
@@ -113,7 +113,7 @@ func unmarshalExpr(kind string, data []byte) (Expr, error) {
 		var percentile exprPercentile
 		e = &percentile
 		err = percentile.UnmarshalJSON(data)
-	case "FNV":
+	case "fnv":
 		var fnv exprFNV
 		e = &fnv
 		err = fnv.UnmarshalJSON(data)

--- a/rule/json.go
+++ b/rule/json.go
@@ -109,8 +109,16 @@ func unmarshalExpr(kind string, data []byte) (Expr, error) {
 		var gt exprGT
 		e = &gt
 		err = gt.UnmarshalJSON(data)
+	case "percentile":
+		var percentile exprPercentile
+		e = &percentile
+		err = percentile.UnmarshalJSON(data)
+	case "FNV":
+		var fnv exprFNV
+		e = &fnv
+		err = fnv.UnmarshalJSON(data)
 	default:
-		err = errors.New("unknown expression kind")
+		err = errors.New("unknown expression kind " + kind)
 	}
 
 	return e, err

--- a/rule/json_test.go
+++ b/rule/json_test.go
@@ -54,6 +54,7 @@ func TestUnmarshalExpr(t *testing.T) {
 			{"not", []byte(`{"kind":"not","operands": [{"kind": "value"}, {"kind": "param"}]}`), new(exprNot)},
 			{"and", []byte(`{"kind":"and","operands": [{"kind": "value"}, {"kind": "param"}]}`), new(exprAnd)},
 			{"or", []byte(`{"kind":"or","operands": [{"kind": "value"}, {"kind": "param"}]}`), new(exprOr)},
+			{"or", []byte(`{"kind":"percentile","operands": [{"kind": "value"}, {"kind": "param"}]}`), new(exprOr)},
 			{"param", []byte(`{"kind":"param"}`), new(Param)},
 			{"value", []byte(`{"kind":"value"}`), new(Value)},
 		}
@@ -130,6 +131,16 @@ func TestRuleUnmarshalling(t *testing.T) {
 					),
 					Not(
 						BoolValue(true),
+					),
+					Percentile(
+						StringValue("Bob Dylan"),
+						Int64Value(96),
+					),
+					Not(
+						Eq(
+							FNV(StringValue("Bob Dylan")),
+							StringValue("Bob Dylan"),
+						),
 					),
 				),
 				True(),


### PR DESCRIPTION
Fixes #99 
Fixes #100 

This PR backports the Percentile operator to release-v0.6.   I also bought FNV along for the ride - I don't know how we'd use it outside the Percentile function, but its an operator on v0.7 so I made it equlivalent. 