### PR TITLE
Fix path collision on eval endpoint

### DIFF
--- a/store/etcd/rulesets.go
+++ b/store/etcd/rulesets.go
@@ -96,14 +96,19 @@ func (s *RulesetService) Latest(ctx context.Context, path string) (*store.Rulese
 		return nil, store.ErrNotFound
 	}
 
-	resp, err := s.Client.KV.Get(ctx, s.rulesetsPath(path, "")+"/", clientv3.WithLastKey()...)
+	resp, err := s.Client.KV.Get(ctx, s.latestRulesetPath(path))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to fetch the entry: %s", path)
+		return nil, errors.Wrapf(err, "failed to fetch latest version: %s", path)
 	}
 
 	// Count will be 0 if the path doesn't exist or if it's not a ruleset.
 	if resp.Count == 0 {
 		return nil, store.ErrNotFound
+	}
+
+	resp, err = s.Client.KV.Get(ctx, string(resp.Kvs[0].Value))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch the entry: %s", path)
 	}
 
 	var entry store.RulesetEntry

--- a/store/etcd/rulesets_test.go
+++ b/store/etcd/rulesets_test.go
@@ -179,10 +179,12 @@ func TestLatest(t *testing.T) {
 	createRuleset(t, s, "a", newRse)
 
 	rs, _ := regula.NewBoolRuleset(rule.New(rule.True(), rule.BoolValue(true)))
+	rs2, _ := regula.NewBoolRuleset(rule.New(rule.True(), rule.BoolValue(false)))
 	createRuleset(t, s, "b", rs)
 	createRuleset(t, s, "c", rs)
 	createRuleset(t, s, "abc", rs)
 	createRuleset(t, s, "abcd", rs)
+	createRuleset(t, s, "abcd/e", rs2)
 
 	t.Run("OK - several versions of a ruleset", func(t *testing.T) {
 		path := "a"
@@ -222,6 +224,16 @@ func TestLatest(t *testing.T) {
 		_, err := s.Latest(context.Background(), path)
 		require.Error(t, err)
 		require.Equal(t, err, store.ErrNotFound)
+	})
+
+	t.Run("OK - ruleset with sub ruleset", func(t *testing.T) {
+		entry, err := s.Latest(context.Background(), "abcd")
+		require.NoError(t, err)
+		require.Equal(t, rs, entry.Ruleset)
+
+		entry, err = s.Latest(context.Background(), "abcd/e")
+		require.NoError(t, err)
+		require.Equal(t, rs2, entry.Ruleset)
 	})
 }
 


### PR DESCRIPTION
This PR fixes #108 by fetching the exact path of the latest version of a given ruleset before fetching the ruleset.
