### PR TITLE
Edit ruleset rules endpoint

### DIFF
--- a/api/server/api_test.go
+++ b/api/server/api_test.go
@@ -404,7 +404,7 @@ func TestAPI(t *testing.T) {
 		call := func(t *testing.T, url string, code int, e *store.RulesetEntry, putErr error) {
 			t.Helper()
 
-			s.PutFn = func(context.Context, string) (*store.RulesetEntry, error) {
+			s.PutFn = func(context.Context, string, *regula.Ruleset) (*store.RulesetEntry, error) {
 				return e, putErr
 			}
 			defer func() { s.PutFn = nil }()

--- a/mock/store.go
+++ b/mock/store.go
@@ -25,8 +25,6 @@ type RulesetService struct {
 	EvalFn           func(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error)
 	EvalVersionCount int
 	EvalVersionFn    func(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
-	PatchCount       int
-	PatchFn          func(context.Context, string) (*store.RulesetEntry, error)
 }
 
 // Get runs GetFn if provided and increments GetCount when invoked.
@@ -88,17 +86,6 @@ func (s *RulesetService) EvalVersion(ctx context.Context, path, version string, 
 
 	if s.EvalVersionFn != nil {
 		return s.EvalVersionFn(ctx, path, version, params)
-	}
-	return nil, nil
-}
-
-// Patch runs PatchFn if provided and increments PatchCount when invoked.
-//
-func (s *RulesetService) Patch(ctx context.Context, path string, ruleset *regula.Ruleset) (*store.RulesetEntry, error) {
-	s.PatchCount++
-
-	if s.PatchFn != nil {
-		return s.PatchFn(ctx, path)
 	}
 	return nil, nil
 }

--- a/mock/store.go
+++ b/mock/store.go
@@ -20,7 +20,7 @@ type RulesetService struct {
 	WatchCount       int
 	WatchFn          func(context.Context, string, string) (*store.RulesetEvents, error)
 	PutCount         int
-	PutFn            func(context.Context, string) (*store.RulesetEntry, error)
+	PutFn            func(context.Context, string, *regula.Ruleset) (*store.RulesetEntry, error)
 	EvalCount        int
 	EvalFn           func(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error)
 	EvalVersionCount int
@@ -65,7 +65,7 @@ func (s *RulesetService) Put(ctx context.Context, path string, ruleset *regula.R
 	s.PutCount++
 
 	if s.PutFn != nil {
-		return s.PutFn(ctx, path)
+		return s.PutFn(ctx, path, ruleset)
 	}
 	return nil, nil
 }

--- a/mock/store.go
+++ b/mock/store.go
@@ -25,6 +25,8 @@ type RulesetService struct {
 	EvalFn           func(ctx context.Context, path string, params rule.Params) (*regula.EvalResult, error)
 	EvalVersionCount int
 	EvalVersionFn    func(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
+	PatchCount       int
+	PatchFn          func(context.Context, string) (*store.RulesetEntry, error)
 }
 
 // Get runs GetFn if provided and increments GetCount when invoked.
@@ -86,6 +88,17 @@ func (s *RulesetService) EvalVersion(ctx context.Context, path, version string, 
 
 	if s.EvalVersionFn != nil {
 		return s.EvalVersionFn(ctx, path, version, params)
+	}
+	return nil, nil
+}
+
+// Patch runs PatchFn if provided and increments PatchCount when invoked.
+//
+func (s *RulesetService) Patch(ctx context.Context, path string, ruleset *regula.Ruleset) (*store.RulesetEntry, error) {
+	s.PatchCount++
+
+	if s.PatchFn != nil {
+		return s.PatchFn(ctx, path)
 	}
 	return nil, nil
 }

--- a/rule/sexpr/parser.go
+++ b/rule/sexpr/parser.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/heetch/regula"
 	"github.com/heetch/regula/rule"
 )
 
@@ -38,6 +39,20 @@ func makeSymbolMap() *opCodeMap {
 }
 
 type Parameters map[string]rule.Type
+
+// Extract typed parameters from a regula.Signature
+func GetParametersFromSignature(sig *regula.Signature) (Parameters, error) {
+	var err error
+	params := make(Parameters)
+
+	for n, t := range sig.ParamTypes {
+		params[n], err = rule.TypeFromName(t)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}
 
 // Parser is a parser for the Regula Symbolic Expression Language.  It
 // should always be constructed by passing an io.Reader to the

--- a/rule/sexpr/parser_test.go
+++ b/rule/sexpr/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/heetch/regula"
 	"github.com/heetch/regula/rule"
 	"github.com/heetch/regula/rule/sexpr"
 	"github.com/stretchr/testify/require"
@@ -65,4 +66,15 @@ func TestParser(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetParametersFromSignature(t *testing.T) {
+	sig := &regula.Signature{
+		ParamTypes: map[string]string{"foo": "string", "bar": "integer"},
+	}
+
+	params, err := sexpr.GetParametersFromSignature(sig)
+	require.NoError(t, err)
+	require.Equal(t, sexpr.Parameters{"foo": rule.STRING, "bar": rule.INTEGER}, params)
+
 }

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -158,11 +158,6 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 	// Write the new entry back to the DB
 	result, err := h.service.Put(r.Context(), path, entry.Ruleset)
 	if err != nil {
-		if err == store.ErrNotFound {
-			writeError(w, r, err, http.StatusNotFound)
-			return
-		}
-
 		writeError(w, r, err, http.StatusInternalServerError)
 		return
 	}

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -147,19 +147,16 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 		return
 	}
 
-	parms := make(sexpr.Parameters)
-	for n, t := range entry.Signature.ParamTypes {
-		parms[n], err = regrule.TypeFromName(t)
-		if err != nil {
-			writeError(w, r, err, http.StatusInternalServerError)
-			return
-		}
+	params, err := sexpr.GetParametersFromSignature(entry.Signature)
+	if err != nil {
+		writeError(w, r, err, http.StatusInternalServerError)
+		return
 	}
 
 	rules := make([]*regrule.Rule, len(nrr.Rules), len(nrr.Rules))
 	for n, rule := range nrr.Rules {
 		p := sexpr.NewParser(bytes.NewBufferString(rule.SExpr))
-		expr, err := p.Parse(parms)
+		expr, err := p.Parse(params)
 		if err != nil {
 			writeError(w, r, newRuleError(n+1, err), http.StatusInternalServerError)
 			return

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -149,7 +149,7 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 	}
 
 	// Update the entry with the new rules
-	err, status := updateEntry(entry, nrr)
+	status, err := updateEntry(entry, nrr)
 	if err != nil {
 		writeError(w, r, err, status)
 		return
@@ -170,10 +170,10 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 }
 
 // updateEntry augments an existing entry with new Rules
-func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) (error, int) {
+func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) (int, error) {
 	params, err := sexpr.GetParametersFromSignature(entry.Signature)
 	if err != nil {
-		return err, http.StatusInternalServerError
+		return http.StatusInternalServerError, err
 	}
 
 	rules := make([]*regrule.Rule, len(nrr.Rules), len(nrr.Rules))
@@ -181,12 +181,12 @@ func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) (error, int)
 		p := sexpr.NewParser(bytes.NewBufferString(rule.SExpr))
 		expr, err := p.Parse(params)
 		if err != nil {
-			return newRuleError(n+1, err), http.StatusBadRequest
+			return http.StatusBadRequest, newRuleError(n+1, err)
 		}
 
 		val, err := makeValue(entry.Signature.ReturnType, rule.ReturnValue)
 		if err != nil {
-			return err, http.StatusInternalServerError
+			return http.StatusInternalServerError, err
 		}
 
 		rules[n] = &regrule.Rule{
@@ -197,9 +197,9 @@ func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) (error, int)
 
 	entry.Ruleset, err = makeRuleset(entry.Signature.ReturnType, rules...)
 	if err != nil {
-		return err, http.StatusInternalServerError
+		return http.StatusInternalServerError, err
 	}
-	return nil, 0
+	return 0, nil
 }
 
 // handleSingleRuleset handles requests for a single ruleset,

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -167,7 +167,7 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 		return
 	}
 	if result == nil {
-		err := fmt.Errorf("No Ruleset found at path: %q", path)
+		err := fmt.Errorf("no Ruleset found at path: %q", path)
 		writeError(w, r, err, http.StatusNotFound)
 		return
 	}

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -158,6 +158,12 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 	// Write the new entry back to the DB
 	result, err := h.service.Put(r.Context(), path, entry.Ruleset)
 	if err != nil {
+		if err == store.ErrNotModified {
+			// This isn't actually a failure - we just
+			// don't have any changes to make.
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		writeError(w, r, err, http.StatusInternalServerError)
 		return
 	}

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -171,7 +171,7 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 		writeError(w, r, err, http.StatusNotFound)
 		return
 	}
-	reghttp.EncodeJSON(w, r, nil, http.StatusNoContent)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // updateEntry augments an existing entry with new Rules

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -132,7 +132,7 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 
 	err := json.NewDecoder(r.Body).Decode(nrr)
 	if err != nil {
-		writeError(w, r, err, http.StatusInternalServerError)
+		writeError(w, r, err, http.StatusBadRequest)
 		return
 	}
 

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -174,6 +174,7 @@ func (h *internalHandler) handleEditRulesetRequest(w http.ResponseWriter, r *htt
 	reghttp.EncodeJSON(w, r, nil, http.StatusNoContent)
 }
 
+// updateEntry augments an existing entry with new Rules
 func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) error {
 	params, err := sexpr.GetParametersFromSignature(entry.Signature)
 	if err != nil {
@@ -206,6 +207,8 @@ func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) error {
 	return nil
 }
 
+// handleSingleRuleset handles requests for a single ruleset,
+// returning the ruleset itself along with version information
 func (h *internalHandler) handleSingleRuleset(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/rulesets/")
 

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -278,23 +278,43 @@ func TestEditRulesetHandler(t *testing.T) {
 		var entry *store.RulesetEntry
 
 		entry = &store.RulesetEntry{
-			Path:      path,
-			Version:   "1",
-			Ruleset:   &regula.Ruleset{},
-			Signature: &regula.Signature{},
-			Versions:  []string{"1"},
+			Path:    path,
+			Version: "1",
+			Ruleset: &regula.Ruleset{
+				Rules: nil,
+				Type:  "string",
+			},
+			Signature: &regula.Signature{
+				ReturnType: "string",
+				ParamTypes: make(map[string]string),
+			},
+			Versions: []string{"1"},
 		}
 		return entry, nil
 
 	}
 
-	s.PutFn = func(ctx context.Context, path string) (*store.RulesetEntry, error) {
+	s.PutFn = func(ctx context.Context, path string, rs *regula.Ruleset) (*store.RulesetEntry, error) {
 		var entry *store.RulesetEntry
+
+		// Assert that the rules we constructed are as expected
+		require.Equal(t, 1, len(rs.Rules))
+
+		expected, ok := regrule.Eq(
+			regrule.Int64Value(1),
+			regrule.Int64Value(1),
+		).(regrule.ComparableExpression)
+		require.Equal(t, true, ok)
+
+		result, ok := rs.Rules[0].Expr.(regrule.ComparableExpression)
+		require.Equal(t, true, ok)
+
+		require.Equal(t, true, expected.Same(result))
 
 		entry = &store.RulesetEntry{
 			Path:      path,
 			Version:   "2",
-			Ruleset:   &regula.Ruleset{},
+			Ruleset:   rs,
 			Signature: &regula.Signature{},
 			Versions:  []string{"1", "2"},
 		}

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -30,12 +30,12 @@ func TestPOSTNewRulesetWithParserError(t *testing.T) {
 	s := new(mock.RulesetService)
 	rec := doRequest(NewHandler(s, http.Dir("")), "POST", "/i/rulesets/",
 		strings.NewReader(`{
-    "path": "Path1",
+		- 0:00:00 :: "path": "Path1",
     "signature": {
         "params": [
             {
                 "name": "foo",
-                "type": "string"
+                "type": "string"0:00:00 
             }
         ],
         "returnType": "string"
@@ -269,4 +269,29 @@ func TestSingleRulesetHandler(t *testing.T) {
 	require.Contains(t, srr.Signature.Params, param{"name": "bar", "type": "string"})
 	require.Equal(t, "string", srr.Signature.ReturnType)
 	require.Equal(t, 1, s.GetCount)
+}
+
+func TestEditRulesetHandler(t *testing.T) {
+	s := new(mock.RulesetService)
+
+	rec := doRequest(NewHandler(s, http.Dir("")), "PATCH", "/i/rulesets/a/nice/ruleset", strings.NewReader(`{
+    "path": "Path1",
+    "signature": {
+        "params": [
+            {
+                "name": "foo",
+                "type": "string"
+            }
+        ],
+        "returnType": "string"
+    },
+    "rules": [
+        {
+            "sExpr": "(= 1 1)",
+            "returnValue": "wibble"
+        }
+    ]
+}`))
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, 1, s.PutCount)
 }

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -30,12 +30,12 @@ func TestPOSTNewRulesetWithParserError(t *testing.T) {
 	s := new(mock.RulesetService)
 	rec := doRequest(NewHandler(s, http.Dir("")), "POST", "/i/rulesets/",
 		strings.NewReader(`{
-		- 0:00:00 :: "path": "Path1",
+    "path": "Path1",
     "signature": {
         "params": [
             {
                 "name": "foo",
-                "type": "string"0:00:00 
+                "type": "string"
             }
         ],
         "returnType": "string"
@@ -50,7 +50,7 @@ func TestPOSTNewRulesetWithParserError(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	body := rec.Body.String()
 	require.JSONEq(t, `{
-    "error": "Error in rule 1: unexpected end of file",
+    "error": "validation",
     "fields": [
 	{
 	    "path": ["rules", "1", "sExpr"],

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -286,7 +286,9 @@ func TestEditRulesetHandler(t *testing.T) {
 			},
 			Signature: &regula.Signature{
 				ReturnType: "string",
-				ParamTypes: make(map[string]string),
+				ParamTypes: map[string]string{
+					"foo": "string",
+				},
 			},
 			Versions: []string{"1"},
 		}
@@ -300,23 +302,29 @@ func TestEditRulesetHandler(t *testing.T) {
 		// Assert that the rules we constructed are as expected
 		require.Equal(t, 1, len(rs.Rules))
 
-		expected, ok := regrule.Eq(
+		expected := regrule.Eq(
 			regrule.Int64Value(1),
-			regrule.Int64Value(1),
-		).(regrule.ComparableExpression)
+			regrule.StringParam("foo"),
+		)
+		comp, ok := expected.(regrule.ComparableExpression)
 		require.Equal(t, true, ok)
 
 		result, ok := rs.Rules[0].Expr.(regrule.ComparableExpression)
 		require.Equal(t, true, ok)
 
-		require.Equal(t, true, expected.Same(result))
+		require.Equal(t, true, comp.Same(result))
 
 		entry = &store.RulesetEntry{
-			Path:      path,
-			Version:   "2",
-			Ruleset:   rs,
-			Signature: &regula.Signature{},
-			Versions:  []string{"1", "2"},
+			Path:    path,
+			Version: "2",
+			Ruleset: rs,
+			Signature: &regula.Signature{
+				ReturnType: "string",
+				ParamTypes: map[string]string{
+					"foo": "string",
+				},
+			},
+			Versions: []string{"1", "2"},
 		}
 		return entry, nil
 	}
@@ -327,7 +335,7 @@ func TestEditRulesetHandler(t *testing.T) {
 	body := strings.NewReader(`{
     "rules": [
         {
-            "sExpr": "(= 1 1)",
+            "sExpr": "(= 1 foo)",
             "returnValue": "wibble"
         }
     ]


### PR DESCRIPTION
Fixes #36 

This PR adds a handler for editing a Rulesets rules.  

Along the way I also:
- corrected the `PutFn` function of the mock `RulesetService`
- added a convenience method for deriving `sexpr.Paramaters` from `regula.Signature` types 