### PR TITLE
New watch api

### DIFF
--- a/api/etcd/list.go
+++ b/api/etcd/list.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"encoding/base64"
-	"strconv"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/heetch/regula/api"
@@ -45,7 +44,7 @@ func (s *RulesetService) List(ctx context.Context, opt api.ListOptions) (*api.Ru
 	}
 
 	rulesets := api.Rulesets{
-		Revision: strconv.FormatInt(resp.Header.Revision, 10),
+		Revision: resp.Header.Revision,
 	}
 
 	rulesets.Paths = make([]string, 0, len(resp.Kvs))

--- a/api/etcd/rulesets_test.go
+++ b/api/etcd/rulesets_test.go
@@ -25,12 +25,10 @@ var (
 	endpoints   = []string{"localhost:2379", "etcd:2379"}
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 func newEtcdRulesetService(t *testing.T) (*RulesetService, func()) {
 	t.Helper()
+
+	rand.Seed(time.Now().UnixNano())
 
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:   endpoints,

--- a/api/etcd/rulesets_test.go
+++ b/api/etcd/rulesets_test.go
@@ -50,6 +50,8 @@ func newEtcdRulesetService(t *testing.T) (*RulesetService, func()) {
 }
 
 func createRuleset(t *testing.T, s *RulesetService, path string, rules ...*rule.Rule) *regula.Ruleset {
+	t.Helper()
+
 	_, err := s.Put(context.Background(), path, rules)
 	if err != nil && err != api.ErrRulesetNotModified {
 		require.NoError(t, err)
@@ -61,6 +63,8 @@ func createRuleset(t *testing.T, s *RulesetService, path string, rules ...*rule.
 }
 
 func createBoolRuleset(t *testing.T, s *RulesetService, path string, rules ...*rule.Rule) *regula.Ruleset {
+	t.Helper()
+
 	err := s.Create(context.Background(), path, &regula.Signature{ReturnType: "bool"})
 	assert.False(t, err != nil && err != api.ErrAlreadyExists)
 	return createRuleset(t, s, path, rules...)

--- a/api/etcd/rulesets_test.go
+++ b/api/etcd/rulesets_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/heetch/regula"
 	"github.com/heetch/regula/api"
 	"github.com/heetch/regula/rule"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +25,7 @@ var (
 	endpoints   = []string{"localhost:2379", "etcd:2379"}
 )
 
-func Init() {
+func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
@@ -55,12 +56,12 @@ func createRuleset(t *testing.T, s *RulesetService, path string, rules ...*rule.
 	}
 
 	rs, err := s.Get(context.Background(), path, "")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	return rs
 }
 
 func createBoolRuleset(t *testing.T, s *RulesetService, path string, rules ...*rule.Rule) *regula.Ruleset {
 	err := s.Create(context.Background(), path, &regula.Signature{ReturnType: "bool"})
-	require.False(t, err != nil && err != api.ErrAlreadyExists)
+	assert.False(t, err != nil && err != api.ErrAlreadyExists)
 	return createRuleset(t, s, path, rules...)
 }

--- a/api/etcd/watch.go
+++ b/api/etcd/watch.go
@@ -15,6 +15,7 @@ import (
 
 // Watch a list of paths for changes and return a list of events. If the list is empty or nil,
 // watch all paths. If the revision is empty, watch from the latest revision.
+// This method blocks until there is a change if one of the paths or until the context is canceled.
 // The given context can be used to limit the watch period or to cancel any running one.
 func (s *RulesetService) Watch(ctx context.Context, paths []string, revision string) (*api.RulesetEvents, error) {
 	ctx, cancel := context.WithCancel(ctx)

--- a/api/etcd/watch.go
+++ b/api/etcd/watch.go
@@ -12,8 +12,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Watch the given prefix for anything new.
-func (s *RulesetService) Watch(ctx context.Context, prefix string, revision string) (*api.RulesetEvents, error) {
+// Watch a list of paths for changes and return a list of events. If the list is empty or nil,
+// watch all paths. If the revision is empty, watch from the latest revision.
+func (s *RulesetService) Watch(ctx context.Context, paths []string, revision string) (*api.RulesetEvents, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -27,27 +28,42 @@ func (s *RulesetService) Watch(ctx context.Context, prefix string, revision stri
 		Revision: revision,
 	}
 
-	wc := s.Client.Watch(ctx, s.rulesPath(prefix, ""), opts...)
+	wc := s.Client.Watch(ctx, s.rulesPath("", ""), opts...)
 	for {
 		select {
 		case wresp := <-wc:
 			if err := wresp.Err(); err != nil {
-				return nil, errors.Wrapf(err, "failed to watch prefix: '%s'", prefix)
+				return nil, errors.Wrapf(err, "failed to watch paths: '%#v'", paths)
 			}
 
 			if len(wresp.Events) == 0 {
 				continue
 			}
 
-			list := make([]api.RulesetEvent, len(wresp.Events))
+			var list []api.RulesetEvent
 			for i, ev := range wresp.Events {
-				switch ev.Type {
-				case mvccpb.PUT:
-					list[i].Type = api.RulesetPutEvent
-				default:
+				// detect if the event key is found in the paths list
+				// or that the paths list is empty
+				ok := len(paths) == 0
+				for i := 0; i < len(paths) && !ok; i++ {
+					if string(ev.Kv.Key) == s.rulesPath(paths[i], "") {
+						ok = true
+					}
+				}
+
+				// filter keys that haven't been selected
+				if !ok {
+					s.Logger.Debug().Str("type", string(ev.Type)).Str("key", string(ev.Kv.Key)).Msg("watch: ignoring event key")
+					continue
+				}
+
+				// filter event types, keep only PUT events
+				if ev.Type != mvccpb.PUT {
 					s.Logger.Debug().Str("type", string(ev.Type)).Msg("watch: ignoring event type")
 					continue
 				}
+
+				list[i].Type = api.RulesetPutEvent
 
 				var pbrs pb.Rules
 				err := proto.Unmarshal(ev.Kv.Value, &pbrs)

--- a/api/etcd/watch.go
+++ b/api/etcd/watch.go
@@ -73,7 +73,8 @@ func (s *RulesetService) Watch(ctx context.Context, paths []string, revision int
 				})
 			}
 
-			// none of the returned events matched the user selection
+    // None of the events matched the user selection, so continue
+    // waiting for more.
 			// we continue watching
 			if len(list) == 0 {
 				continue

--- a/api/etcd/watch.go
+++ b/api/etcd/watch.go
@@ -73,8 +73,8 @@ func (s *RulesetService) Watch(ctx context.Context, paths []string, revision int
 				})
 			}
 
-    // None of the events matched the user selection, so continue
-    // waiting for more.
+			// None of the events matched the user selection, so continue
+			// waiting for more.
 			// we continue watching
 			if len(list) == 0 {
 				continue

--- a/api/etcd/watch.go
+++ b/api/etcd/watch.go
@@ -59,9 +59,10 @@ func (s *RulesetService) Watch(ctx context.Context, paths []string, revision int
 				var pbrs pb.Rules
 				err := proto.Unmarshal(ev.Kv.Value, &pbrs)
 				if err != nil {
-					s.Logger.Debug().Bytes("entry", ev.Kv.Value).Msg("watch: unmarshalling failed")
-					return nil, errors.Wrap(err, "failed to unmarshal entry")
+					s.Logger.Error().Bytes("entry", ev.Kv.Value).Msg("watch: unmarshalling failed, ignoring the event")
+					continue
 				}
+
 				path, version := s.pathVersionFromKey(string(ev.Kv.Key))
 
 				list = append(list, api.RulesetEvent{

--- a/api/etcd/watch.go
+++ b/api/etcd/watch.go
@@ -15,6 +15,7 @@ import (
 
 // Watch a list of paths for changes and return a list of events. If the list is empty or nil,
 // watch all paths. If the revision is empty, watch from the latest revision.
+// The given context can be used to limit the watch period or to cancel any running one.
 func (s *RulesetService) Watch(ctx context.Context, paths []string, revision string) (*api.RulesetEvents, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/api/etcd/watch.go
+++ b/api/etcd/watch.go
@@ -14,7 +14,7 @@ import (
 
 // Watch a list of paths for changes and return a list of events. If paths is empty or nil,
 // watch all paths. If the revision is negative, watch from the latest revision.
-// This method blocks until there is a change if one of the paths or until the context is canceled.
+// This method blocks until there is a change in one of the paths or until the context is canceled.
 // The given context can be used to limit the watch period or to cancel any running one.
 func (s *RulesetService) Watch(ctx context.Context, opt api.WatchOptions) (*api.RulesetEvents, error) {
 	ctx, cancel := context.WithCancel(ctx)
@@ -77,7 +77,6 @@ func (s *RulesetService) Watch(ctx context.Context, opt api.WatchOptions) (*api.
 
 			// None of the events matched the user selection, so continue
 			// waiting for more.
-			// we continue watching
 			if len(list) == 0 {
 				continue
 			}

--- a/api/etcd/watch_test.go
+++ b/api/etcd/watch_test.go
@@ -48,7 +48,7 @@ func TestWatch(t *testing.T) {
 			defer cancel()
 
 			var events api.RulesetEvents
-			var rev string
+			var rev int64
 			var watchCount int
 			for len(events.Events) != len(test.expected) && watchCount < 4 {
 				evs, err := s.Watch(ctx, test.paths, rev)
@@ -85,7 +85,7 @@ func TestWatch(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 		defer cancel()
-		events, err := s.Watch(ctx, nil, "")
+		events, err := s.Watch(ctx, nil, -1)
 		require.Equal(t, context.DeadlineExceeded, err)
 		require.True(t, events.Timeout)
 	})

--- a/api/etcd/watch_test.go
+++ b/api/etcd/watch_test.go
@@ -53,7 +53,7 @@ func TestWatch(t *testing.T) {
 			var rev int64
 			var watchCount int
 			for len(events.Events) != len(test.expected) && watchCount < 4 {
-				evs, err := s.Watch(ctx, test.paths, rev)
+				evs, err := s.Watch(ctx, api.WatchOptions{Paths: test.paths, Revision: rev})
 				if err != nil {
 					if err != nil {
 						if err == context.DeadlineExceeded {
@@ -94,7 +94,7 @@ func TestWatch(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 		defer cancel()
-		events, err := s.Watch(ctx, nil, -1)
+		events, err := s.Watch(ctx, api.WatchOptions{})
 		require.Equal(t, context.DeadlineExceeded, err)
 		require.True(t, events.Timeout)
 	})

--- a/api/etcd/watch_test.go
+++ b/api/etcd/watch_test.go
@@ -55,17 +55,17 @@ func TestWatch(t *testing.T) {
 			for len(events.Events) != len(test.expected) && watchCount < 4 {
 				evs, err := s.Watch(ctx, test.paths, rev)
 				if err != nil {
-if err != nil {
-    if err == context.DeadlineExceeded {
-       t.Errorf("timed out waiting for expected events")
-    } else {
-       t.Errorf("unexpected error from watcher: %v", err)
-    }
-   break
-}
+					if err != nil {
+						if err == context.DeadlineExceeded {
+							t.Errorf("timed out waiting for expected events")
+						} else {
+							t.Errorf("unexpected error from watcher: %v", err)
+						}
+						break
+					}
 					break
 				}
-assert.True(t, len(evs.Events) > 0)
+				assert.True(t, len(evs.Events) > 0)
 				assert.NotEmpty(t, evs.Revision)
 				rev = evs.Revision
 				events.Events = append(events.Events, evs.Events...)

--- a/api/etcd/watch_test.go
+++ b/api/etcd/watch_test.go
@@ -35,6 +35,8 @@ func TestWatch(t *testing.T) {
 			go func() {
 				defer wg.Done()
 
+				// wait enought time so that the other goroutine had the time to run the watch method
+				// before writing data to the database.
 				time.Sleep(time.Second)
 
 				r := rule.New(rule.True(), rule.BoolValue(true))

--- a/api/etcd/watch_test.go
+++ b/api/etcd/watch_test.go
@@ -55,10 +55,17 @@ func TestWatch(t *testing.T) {
 			for len(events.Events) != len(test.expected) && watchCount < 4 {
 				evs, err := s.Watch(ctx, test.paths, rev)
 				if err != nil {
-					assert.Equal(t, err, context.DeadlineExceeded)
+if err != nil {
+    if err == context.DeadlineExceeded {
+       t.Errorf("timed out waiting for expected events")
+    } else {
+       t.Errorf("unexpected error from watcher: %v", err)
+    }
+   break
+}
 					break
 				}
-				assert.True(t, len(evs.Events) >= 1)
+assert.True(t, len(evs.Events) > 0)
 				assert.NotEmpty(t, evs.Revision)
 				rev = evs.Revision
 				events.Events = append(events.Events, evs.Events...)

--- a/api/service.go
+++ b/api/service.go
@@ -29,8 +29,8 @@ type RulesetService interface {
 	// List returns the list of all rulesets paths.
 	// The listing is paginated and can be customised using the ListOptions type.
 	List(ctx context.Context, opt ListOptions) (*Rulesets, error)
-	// Watch a list of paths for changes and return a list of events. If the list is empty or nil,
-	// watch all paths. If the revision is negative, watch from the latest revision.
+	// Watch a list of paths for changes and return a list of events.
+	// The watcher can be customized using the WatchOption type.
 	Watch(ctx context.Context, opt WatchOptions) (*RulesetEvents, error)
 	// Eval evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
 	Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
@@ -63,7 +63,7 @@ type WatchOptions struct {
 	Paths []string
 	// Indicates from which revision start watching.
 	// Any event happened after that revision is returned.
-	// If 0, watch from the latest revision.
+	// If the revision is zero or negative, watch from the latest revision.
 	Revision int64
 }
 

--- a/api/service.go
+++ b/api/service.go
@@ -29,8 +29,9 @@ type RulesetService interface {
 	// List returns the list of all rulesets paths.
 	// The listing is paginated and can be customised using the ListOptions type.
 	List(ctx context.Context, opt ListOptions) (*Rulesets, error)
-	// Watch a prefix for changes and return a list of events.
-	Watch(ctx context.Context, prefix string, revision string) (*RulesetEvents, error)
+	// Watch a list of paths for changes and return a list of events. If the list is empty or nil,
+	// watch all paths. If the revision is empty, watch from the latest revision.
+	Watch(ctx context.Context, paths []string, revision string) (*RulesetEvents, error)
 	// Eval evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
 	Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
 }

--- a/api/service.go
+++ b/api/service.go
@@ -78,7 +78,7 @@ type RulesetEvent struct {
 
 // RulesetEvents holds a list of events occured on a group of rulesets.
 type RulesetEvents struct {
-	Events   []RulesetEvent
-	Revision string
-	Timeout  bool // indicates if the watch did timeout
+	Events   []RulesetEvent `json:"events"`
+	Revision int64          `json:"revision"`
+	Timeout  bool           `json:"timeout"` // indicates if the watch did timeout
 }

--- a/api/service.go
+++ b/api/service.go
@@ -59,7 +59,7 @@ func (l *ListOptions) GetLimit() int {
 // Rulesets holds a list of rulesets.
 type Rulesets struct {
 	Paths    []string `json:"paths"`
-	Revision string   `json:"revision"`         // revision when the request was applied
+	Revision int64    `json:"revision"`         // revision when the request was applied
 	Cursor   string   `json:"cursor,omitempty"` // cursor of the next page, if any
 }
 

--- a/api/service.go
+++ b/api/service.go
@@ -31,7 +31,7 @@ type RulesetService interface {
 	List(ctx context.Context, opt ListOptions) (*Rulesets, error)
 	// Watch a list of paths for changes and return a list of events. If the list is empty or nil,
 	// watch all paths. If the revision is negative, watch from the latest revision.
-	Watch(ctx context.Context, paths []string, revision int64) (*RulesetEvents, error)
+	Watch(ctx context.Context, opt WatchOptions) (*RulesetEvents, error)
 	// Eval evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
 	Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
 }
@@ -54,6 +54,17 @@ func (l *ListOptions) GetLimit() int {
 	}
 
 	return l.Limit
+}
+
+// WatchOptions gives indications on what rulesets to watch.
+type WatchOptions struct {
+	// List of paths to watch for changes.
+	// If the slice is empty, watch all paths.
+	Paths []string
+	// Indicates from which revision start watching.
+	// Any event happened after that revision is returned.
+	// If 0, watch from the latest revision.
+	Revision int64
 }
 
 // Rulesets holds a list of rulesets.

--- a/api/service.go
+++ b/api/service.go
@@ -30,8 +30,8 @@ type RulesetService interface {
 	// The listing is paginated and can be customised using the ListOptions type.
 	List(ctx context.Context, opt ListOptions) (*Rulesets, error)
 	// Watch a list of paths for changes and return a list of events. If the list is empty or nil,
-	// watch all paths. If the revision is empty, watch from the latest revision.
-	Watch(ctx context.Context, paths []string, revision string) (*RulesetEvents, error)
+	// watch all paths. If the revision is negative, watch from the latest revision.
+	Watch(ctx context.Context, paths []string, revision int64) (*RulesetEvents, error)
 	// Eval evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
 	Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)
 }

--- a/http/server/api.go
+++ b/http/server/api.go
@@ -191,10 +191,15 @@ func (s *rulesetAPI) watch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	rev, err := strconv.ParseInt(r.URL.Query().Get("revision"), 10, 64)
-	if err != nil {
-		writeError(w, r, err, http.StatusBadRequest)
-		return
+	revision := r.URL.Query().Get("revision")
+	var rev int64 = -1
+	var err error
+	if revision != "" {
+		rev, err = strconv.ParseInt(revision, 10, 64)
+		if err != nil {
+			writeError(w, r, err, http.StatusBadRequest)
+			return
+		}
 	}
 
 	events, err := s.rulesets.Watch(r.Context(), paths, rev)

--- a/http/server/api.go
+++ b/http/server/api.go
@@ -21,6 +21,7 @@ type rulesetAPI struct {
 
 func (s *rulesetAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
+	r.ParseForm()
 
 	switch r.Method {
 	case "GET":

--- a/http/server/api.go
+++ b/http/server/api.go
@@ -191,13 +191,6 @@ func (s *rulesetAPI) watch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if r.ContentLength > 0 {
-		err := json.NewDecoder(r.Body).Decode(&paths)
-		if err != nil {
-			writeError(w, r, err, http.StatusBadRequest)
-			return
-		}
-	}
 
 	revision := r.URL.Query().Get("revision")
 	var rev int64 = -1

--- a/http/server/api.go
+++ b/http/server/api.go
@@ -182,7 +182,15 @@ func (s *rulesetAPI) eval(w http.ResponseWriter, r *http.Request, path string) {
 func (s *rulesetAPI) watch(w http.ResponseWriter, r *http.Request) {
 	var paths []string
 
-	// an empty body means watch all paths
+	if r.ContentLength > 0 {
+		// There's a non-empty body, which means that the
+		// client has specified a set of paths to watch.
+		err := json.NewDecoder(r.Body).Decode(&paths)
+		if err != nil {
+			writeError(w, r, err, http.StatusBadRequest)
+			return
+		}
+	}
 	if r.ContentLength > 0 {
 		err := json.NewDecoder(r.Body).Decode(&paths)
 		if err != nil {

--- a/http/server/api.go
+++ b/http/server/api.go
@@ -191,7 +191,13 @@ func (s *rulesetAPI) watch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	events, err := s.rulesets.Watch(r.Context(), paths, r.URL.Query().Get("revision"))
+	rev, err := strconv.ParseInt(r.URL.Query().Get("revision"), 10, 64)
+	if err != nil {
+		writeError(w, r, err, http.StatusBadRequest)
+		return
+	}
+
+	events, err := s.rulesets.Watch(r.Context(), paths, rev)
 	if err != nil {
 		switch err {
 		case context.Canceled:

--- a/http/server/api.go
+++ b/http/server/api.go
@@ -24,7 +24,7 @@ func (s *rulesetAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "GET":
-		if _, ok := r.URL.Query()["list"]; ok {
+		if len(r.Form["list"]) > 0 {
 			if len(path) != 0 {
 				w.WriteHeader(http.StatusNotFound)
 				return
@@ -32,14 +32,14 @@ func (s *rulesetAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.list(w, r)
 			return
 		}
-		if _, ok := r.URL.Query()["eval"]; ok {
+		if len(r.Form["eval"]) > 0 {
 			s.eval(w, r, path)
 			return
 		}
 		s.get(w, r, path)
 		return
 	case "POST":
-		if _, ok := r.URL.Query()["watch"]; ok {
+		if len(r.Form["watch"]) > 0 {
 			if len(path) != 0 {
 				w.WriteHeader(http.StatusNotFound)
 				return

--- a/http/server/api.go
+++ b/http/server/api.go
@@ -143,7 +143,7 @@ func (s *rulesetAPI) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reghttp.EncodeJSON(w, r, (*api.Rulesets)(rulesets), http.StatusOK)
+	reghttp.EncodeJSON(w, r, rulesets, http.StatusOK)
 }
 
 func (s *rulesetAPI) eval(w http.ResponseWriter, r *http.Request, path string) {

--- a/http/server/api_test.go
+++ b/http/server/api_test.go
@@ -49,7 +49,6 @@ func TestServer(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/", nil)
-	r.ParseForm()
 	h.ServeHTTP(w, r)
 	require.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -84,7 +83,6 @@ func TestServerGet(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", test.path, nil)
-			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -150,7 +148,6 @@ func TestServerList(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", test.path, nil)
-			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -215,7 +212,6 @@ func TestServerEval(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", test.path, nil)
-			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -236,7 +232,6 @@ func TestServerEval(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", "/rulesets/path/to/my/ruleset?eval&foo=10", nil)
-			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusBadRequest, w.Code)
@@ -291,7 +286,6 @@ func TestServerWatch(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("POST", test.path, strings.NewReader(test.body))
-			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -350,7 +344,6 @@ func TestServerPut(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("PUT", test.path, &buf)
-			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -398,7 +391,6 @@ func TestServerCreate(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("POST", test.path, &buf)
-			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)

--- a/http/server/api_test.go
+++ b/http/server/api_test.go
@@ -290,16 +290,17 @@ func TestServerWatch(t *testing.T) {
 
 			require.Equal(t, test.status, w.Code)
 
-			if test.status == http.StatusOK {
-				var res api.RulesetEvents
-				require.True(t, w.Body.Len() > 0)
-				err := json.NewDecoder(w.Body).Decode(&res)
-				require.NoError(t, err)
-				if len(res.Events) > 0 {
-					require.Equal(t, len(l.Events), len(res.Events))
-					for i := range l.Events {
-						require.Equal(t, l.Events[i], res.Events[i])
-					}
+			if test.status != http.StatusOK {
+				return
+			}
+			var res api.RulesetEvents
+			require.True(t, w.Body.Len() > 0)
+			err := json.NewDecoder(w.Body).Decode(&res)
+			require.NoError(t, err)
+			if len(res.Events) > 0 {
+				require.Equal(t, len(l.Events), len(res.Events))
+				for i := range l.Events {
+					require.Equal(t, l.Events[i], res.Events[i])
 				}
 			}
 		})

--- a/http/server/api_test.go
+++ b/http/server/api_test.go
@@ -49,6 +49,7 @@ func TestServer(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/", nil)
+	r.ParseForm()
 	h.ServeHTTP(w, r)
 	require.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -83,6 +84,7 @@ func TestServerGet(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", test.path, nil)
+			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -107,7 +109,7 @@ func TestServerList(t *testing.T) {
 
 	rss := api.Rulesets{
 		Paths:    []string{"aa", "bb"},
-		Revision: "somerev",
+		Revision: 10,
 		Cursor:   "somecursor",
 	}
 
@@ -148,6 +150,7 @@ func TestServerList(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", test.path, nil)
+			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -212,6 +215,7 @@ func TestServerEval(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", test.path, nil)
+			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -232,6 +236,7 @@ func TestServerEval(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", "/rulesets/path/to/my/ruleset?eval&foo=10", nil)
+			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusBadRequest, w.Code)
@@ -286,6 +291,7 @@ func TestServerWatch(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("POST", test.path, strings.NewReader(test.body))
+			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -344,6 +350,7 @@ func TestServerPut(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("PUT", test.path, &buf)
+			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)
@@ -391,6 +398,7 @@ func TestServerCreate(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("POST", test.path, &buf)
+			r.ParseForm()
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, test.status, w.Code)

--- a/http/server/api_test.go
+++ b/http/server/api_test.go
@@ -119,11 +119,12 @@ func TestServerList(t *testing.T) {
 		err    error
 	}{
 		{"OK", "/rulesets/?list", http.StatusOK, &rss, api.ListOptions{}, nil},
-		{"WithLimitAndCursor", "/rulesets/a?list&limit=10&cursor=abc123", http.StatusOK, &rss, api.ListOptions{Limit: 10, Cursor: "abc123"}, nil},
+		{"WithLimitAndCursor", "/rulesets/?list&limit=10&cursor=abc123", http.StatusOK, &rss, api.ListOptions{Limit: 10, Cursor: "abc123"}, nil},
 		{"NoResult", "/rulesets/?list", http.StatusOK, new(api.Rulesets), api.ListOptions{}, nil},
-		{"InvalidCursor", "/rulesets/someprefix?list&cursor=abc123", http.StatusBadRequest, new(api.Rulesets), api.ListOptions{Cursor: "abc123"}, api.ErrInvalidCursor},
-		{"UnexpectedError", "/rulesets/someprefix?list", http.StatusInternalServerError, new(api.Rulesets), api.ListOptions{}, errors.New("unexpected error")},
-		{"InvalidLimit", "/rulesets/someprefix?list&limit=badlimit", http.StatusBadRequest, nil, api.ListOptions{}, nil},
+		{"InvalidCursor", "/rulesets/?list&cursor=abc123", http.StatusBadRequest, new(api.Rulesets), api.ListOptions{Cursor: "abc123"}, api.ErrInvalidCursor},
+		{"UnexpectedError", "/rulesets/?list", http.StatusInternalServerError, new(api.Rulesets), api.ListOptions{}, errors.New("unexpected error")},
+		{"InvalidLimit", "/rulesets/?list&limit=badlimit", http.StatusBadRequest, nil, api.ListOptions{}, nil},
+		{"WithPath", "/rulesets/some/path?list&limit=badlimit", http.StatusNotFound, nil, api.ListOptions{}, nil},
 	}
 
 	for _, test := range tests {
@@ -267,7 +268,7 @@ func TestServerWatch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		s.WatchFn = func(context.Context, string, string) (*api.RulesetEvents, error) {
+		s.WatchFn = func(context.Context, []string, string) (*api.RulesetEvents, error) {
 			return test.es, test.err
 		}
 		defer func() { s.WatchFn = nil }()

--- a/http/server/handler.go
+++ b/http/server/handler.go
@@ -37,19 +37,14 @@ func NewHandler(rsService api.RulesetService, cfg Config) http.Handler {
 	}
 
 	rulesetsHandler := rulesetAPI{
-		rulesets: rsService,
+		rulesets:       rsService,
+		watchTimeout:   cfg.WatchTimeout,
+		watchCancelCtx: cfg.WatchCancelCtx,
 	}
 
 	// router
 	mux := http.NewServeMux()
 	mux.Handle("/rulesets/", http.StripPrefix("/rulesets/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if _, ok := r.URL.Query()["watch"]; ok && r.Method == "GET" {
-			ctx, cancel := context.WithTimeout(cfg.WatchCancelCtx, cfg.WatchTimeout)
-			defer cancel()
-			rulesetsHandler.ServeHTTP(w, r.WithContext(ctx))
-			return
-		}
-
 		ctx, cancel := context.WithTimeout(r.Context(), cfg.Timeout)
 		defer cancel()
 		rulesetsHandler.ServeHTTP(w, r.WithContext(ctx))

--- a/mock/store.go
+++ b/mock/store.go
@@ -20,7 +20,7 @@ type RulesetService struct {
 	ListCount   int
 	ListFn      func(context.Context, api.ListOptions) (*api.Rulesets, error)
 	WatchCount  int
-	WatchFn     func(context.Context, []string, string) (*api.RulesetEvents, error)
+	WatchFn     func(context.Context, []string, int64) (*api.RulesetEvents, error)
 	PutCount    int
 	PutFn       func(context.Context, string, []*rule.Rule) (string, error)
 	EvalCount   int
@@ -61,7 +61,7 @@ func (s *RulesetService) List(ctx context.Context, opt api.ListOptions) (*api.Ru
 }
 
 // Watch runs WatchFn if provided and increments WatchCount when invoked.
-func (s *RulesetService) Watch(ctx context.Context, paths []string, revision string) (*api.RulesetEvents, error) {
+func (s *RulesetService) Watch(ctx context.Context, paths []string, revision int64) (*api.RulesetEvents, error) {
 	s.WatchCount++
 
 	if s.WatchFn != nil {

--- a/mock/store.go
+++ b/mock/store.go
@@ -20,7 +20,7 @@ type RulesetService struct {
 	ListCount   int
 	ListFn      func(context.Context, api.ListOptions) (*api.Rulesets, error)
 	WatchCount  int
-	WatchFn     func(context.Context, string, string) (*api.RulesetEvents, error)
+	WatchFn     func(context.Context, []string, string) (*api.RulesetEvents, error)
 	PutCount    int
 	PutFn       func(context.Context, string, []*rule.Rule) (string, error)
 	EvalCount   int
@@ -61,11 +61,11 @@ func (s *RulesetService) List(ctx context.Context, opt api.ListOptions) (*api.Ru
 }
 
 // Watch runs WatchFn if provided and increments WatchCount when invoked.
-func (s *RulesetService) Watch(ctx context.Context, prefix, revision string) (*api.RulesetEvents, error) {
+func (s *RulesetService) Watch(ctx context.Context, paths []string, revision string) (*api.RulesetEvents, error) {
 	s.WatchCount++
 
 	if s.WatchFn != nil {
-		return s.WatchFn(ctx, prefix, revision)
+		return s.WatchFn(ctx, paths, revision)
 	}
 
 	return nil, nil

--- a/mock/store.go
+++ b/mock/store.go
@@ -20,7 +20,7 @@ type RulesetService struct {
 	ListCount   int
 	ListFn      func(context.Context, api.ListOptions) (*api.Rulesets, error)
 	WatchCount  int
-	WatchFn     func(context.Context, []string, int64) (*api.RulesetEvents, error)
+	WatchFn     func(context.Context, api.WatchOptions) (*api.RulesetEvents, error)
 	PutCount    int
 	PutFn       func(context.Context, string, []*rule.Rule) (string, error)
 	EvalCount   int
@@ -61,11 +61,11 @@ func (s *RulesetService) List(ctx context.Context, opt api.ListOptions) (*api.Ru
 }
 
 // Watch runs WatchFn if provided and increments WatchCount when invoked.
-func (s *RulesetService) Watch(ctx context.Context, paths []string, revision int64) (*api.RulesetEvents, error) {
+func (s *RulesetService) Watch(ctx context.Context, opt api.WatchOptions) (*api.RulesetEvents, error) {
 	s.WatchCount++
 
 	if s.WatchFn != nil {
-		return s.WatchFn(ctx, paths, revision)
+		return s.WatchFn(ctx, opt)
 	}
 
 	return nil, nil


### PR DESCRIPTION
This PR refreshes the Watch API according to what has been decided in issue #112 

The Watch API is now accessible under the following endpoint:
```
// URL
POST /rulesets/?watch

// Optional query params
?revision

// Payload
{
  "paths": [
    "pathA",
    "pathB",
   ],
  "revision": 10
}
```

The body specifies which paths you want to watch.
An empty body means watch everything.

This PR also contains a few improvements in the `server` package