### PR TITLE
Fix Create API

### DIFF
--- a/api/etcd/watch.go
+++ b/api/etcd/watch.go
@@ -100,16 +100,15 @@ func (s *RulesetService) Watch(ctx context.Context, opt api.WatchOptions) (*api.
 // shouldIncludeEvent reports whether the given event should be included
 // in the Watch data for the given paths.
 func (s *RulesetService) shouldIncludeEvent(ev *clientv3.Event, paths []string) bool {
-	// detect if the event key is found in the paths list
-	// or that the paths list is empty
+	if len(paths) == 0 {
+		return true
+	}
 	key := string(ev.Kv.Key)
 	key = key[:strings.Index(key, versionSeparator)]
-	ok := len(paths) == 0
-	for i := 0; i < len(paths) && !ok; i++ {
-		if key == s.rulesPath(paths[i], "") {
-			ok = true
+	for _, path := range paths {
+		if s.rulesPath(path, "") == key {
+			return true
 		}
 	}
-
-	return ok
+	return false
 }

--- a/api/etcd/watch_test.go
+++ b/api/etcd/watch_test.go
@@ -35,7 +35,7 @@ func TestWatch(t *testing.T) {
 			go func() {
 				defer wg.Done()
 
-				// wait enought time so that the other goroutine had the time to run the watch method
+				// wait enough time so that the other goroutine had the time to run the watch method
 				// before writing data to the database.
 				time.Sleep(time.Second)
 
@@ -55,13 +55,10 @@ func TestWatch(t *testing.T) {
 			for len(events.Events) != len(test.expected) && watchCount < 4 {
 				evs, err := s.Watch(ctx, api.WatchOptions{Paths: test.paths, Revision: rev})
 				if err != nil {
-					if err != nil {
-						if err == context.DeadlineExceeded {
-							t.Errorf("timed out waiting for expected events")
-						} else {
-							t.Errorf("unexpected error from watcher: %v", err)
-						}
-						break
+					if err == context.DeadlineExceeded {
+						t.Errorf("timed out waiting for expected events")
+					} else {
+						t.Errorf("unexpected error from watcher: %v", err)
 					}
 					break
 				}

--- a/api/service.go
+++ b/api/service.go
@@ -30,7 +30,7 @@ type RulesetService interface {
 	// The listing is paginated and can be customised using the ListOptions type.
 	List(ctx context.Context, opt ListOptions) (*Rulesets, error)
 	// Watch a list of paths for changes and return a list of events.
-	// The watcher can be customized using the WatchOption type.
+	// The watcher can be customized using the WatchOptions type.
 	Watch(ctx context.Context, opt WatchOptions) (*RulesetEvents, error)
 	// Eval evaluates a ruleset given a path and a set of parameters. It implements the regula.Evaluator interface.
 	Eval(ctx context.Context, path, version string, params rule.Params) (*regula.EvalResult, error)

--- a/http/server/api.go
+++ b/http/server/api.go
@@ -195,7 +195,7 @@ func (s *rulesetAPI) eval(w http.ResponseWriter, r *http.Request, path string) {
 
 // watch is a long polling endpoint that watches a list of paths for change and returns a list of events containing all the changes
 // that happened since the start of the watch.
-// If the revision query param is specified, it returns anything that happened after that revision.
+// If the revision option is specified, it returns anything that happened after that revision.
 // If no paths are specificied, it watches any path.
 // The request context can be used to limit the watch period or to cancel any running one.
 func (s *rulesetAPI) watch(w http.ResponseWriter, r *http.Request) {

--- a/http/server/api_test.go
+++ b/http/server/api_test.go
@@ -366,7 +366,7 @@ func TestServerCreate(t *testing.T) {
 		WatchTimeout: 1 * time.Second,
 	})
 
-	sig := regula.Signature{ReturnType: "int64"}
+	sig := createSignaturePayload{Signature: regula.Signature{ReturnType: "int64"}, Path: "a"}
 
 	tests := []struct {
 		name   string
@@ -374,9 +374,9 @@ func TestServerCreate(t *testing.T) {
 		status int
 		err    error
 	}{
-		{"OK", "/rulesets/a", http.StatusCreated, nil},
-		{"StoreError", "/rulesets/a", http.StatusInternalServerError, errors.New("some error")},
-		{"Validation error", "/rulesets/a", http.StatusBadRequest, new(api.ValidationError)},
+		{"OK", "/rulesets/", http.StatusCreated, nil},
+		{"StoreError", "/rulesets/", http.StatusInternalServerError, errors.New("some error")},
+		{"Validation error", "/rulesets/", http.StatusBadRequest, new(api.ValidationError)},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The HTTP Create API was defined like this:

```
POST /rulesets/<path>
{// signature
  "returnType": "foo",
  "params": {}
} 
```

I changed it to
```
POST /rulesets/
{
  "path": "bar",
  "returnType": "foo",
  "params": {}
} 
```

which seems more correct