### PR TITLE
Consult ruleset version endpoint

### DIFF
--- a/ui/handler.go
+++ b/ui/handler.go
@@ -211,7 +211,7 @@ func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) (int, error)
 // handleSingleRuleset handles requests for a single ruleset,
 // returning the ruleset itself along with version information.
 // Should a version parameter be passed in the query string of a
-// request, that specific version of the rule set is returned,
+// request, that specific version of the ruleset is returned,
 // otherwise, the latest version is returned.
 func (h *internalHandler) handleSingleRuleset(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/rulesets/")

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -217,11 +217,19 @@ func (h *internalHandler) handleSingleRuleset(w http.ResponseWriter, r *http.Req
 		h.handleListRequest(w, r)
 		return
 	}
+
+	qs := r.URL.Query()
+	version := ""
+	versions, found := qs["version"]
+	if found {
+		version = versions[0]
+	}
+
 	srr := &singleRulesetResponse{
 		Path: path,
 	}
 
-	entry, err := h.service.Get(r.Context(), path, "")
+	entry, err := h.service.Get(r.Context(), path, version)
 	if err != nil {
 		logger := reghttp.LoggerFromRequest(r)
 		logger.Debug().Msg("foo")

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -208,8 +208,11 @@ func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) (int, error)
 	return 0, nil
 }
 
-// handleSingleRuleset handles requests for a single ruleset,
-// returning the ruleset itself along with version information
+// handleSingleRuleset handles requests for a single rule set,
+// returning the ruleset itself along with version information.
+// Should a version parameter be passed in the query string of a
+// request, that specific version of the rule set is returned,
+// otherwise, the latest version is returned.
 func (h *internalHandler) handleSingleRuleset(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/rulesets/")
 

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -208,7 +208,7 @@ func updateEntry(entry *store.RulesetEntry, nrr *newRulesetRequest) (int, error)
 	return 0, nil
 }
 
-// handleSingleRuleset handles requests for a single rule set,
+// handleSingleRuleset handles requests for a single ruleset,
 // returning the ruleset itself along with version information.
 // Should a version parameter be passed in the query string of a
 // request, that specific version of the rule set is returned,

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -227,6 +227,8 @@ func TestSingleRulesetHandler(t *testing.T) {
 
 	s.GetFn = func(ctx context.Context, path, v string) (*store.RulesetEntry, error) {
 		require.Equal(t, "a/nice/ruleset", path)
+		// No stray data gets put into version
+		require.Equal(t, "", v)
 
 		entry := &store.RulesetEntry{
 			Path:    path,
@@ -265,6 +267,59 @@ func TestSingleRulesetHandler(t *testing.T) {
 	require.Equal(t, "a/nice/ruleset", srr.Path)
 	require.Equal(t, "2", srr.Version)
 	require.Equal(t, []rule{{SExpr: "#true", ReturnValue: "\"Hello\""}}, srr.Ruleset)
+	require.Contains(t, srr.Signature.Params, param{"name": "foo", "type": "int64"})
+	require.Contains(t, srr.Signature.Params, param{"name": "bar", "type": "string"})
+	require.Equal(t, "string", srr.Signature.ReturnType)
+	require.Equal(t, 1, s.GetCount)
+}
+
+func TestSingleRulesetHandlerWithVersion(t *testing.T) {
+	s := new(mock.RulesetService)
+
+	s.GetFn = func(ctx context.Context, path, v string) (*store.RulesetEntry, error) {
+		require.Equal(t, "a/nice/ruleset", path)
+
+		// This is the most important part here - the version
+		// string is extracted correctly.
+		require.Equal(t, "1", v)
+
+		entry := &store.RulesetEntry{
+			Path:    path,
+			Version: "1",
+			Ruleset: &regula.Ruleset{
+				Rules: []*regrule.Rule{
+					&regrule.Rule{
+						Expr:   regrule.BoolValue(false),
+						Result: regrule.StringValue("Goodbye"),
+					},
+				},
+				Type: "string",
+			}, //    *regula.Ruleset
+			Signature: &regula.Signature{
+				ParamTypes: map[string]string{
+					"foo": "int64",
+					"bar": "string",
+				},
+				ReturnType: "string",
+			}, //*regula.Signature
+			Versions: []string{"1", "2"},
+		}
+		return entry, nil
+	}
+	defer func() { s.GetFn = nil }()
+
+	rec := doRequest(NewHandler(s, http.Dir("")), "GET", "/i/rulesets/a/nice/ruleset?version=1", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.Bytes()
+	// Note: we could use require.JSONEq here, but the ordering of
+	// params and rules are not stable and JSONEq can't cope with
+	// disparate ordering.
+	srr := &singleRulesetResponse{}
+	err := json.Unmarshal(body, srr)
+	require.NoError(t, err)
+	require.Equal(t, "a/nice/ruleset", srr.Path)
+	require.Equal(t, "1", srr.Version)
+	require.Equal(t, []rule{{SExpr: "#false", ReturnValue: "\"Goodbye\""}}, srr.Ruleset)
 	require.Contains(t, srr.Signature.Params, param{"name": "foo", "type": "int64"})
 	require.Contains(t, srr.Signature.Params, param{"name": "bar", "type": "string"})
 	require.Equal(t, "string", srr.Signature.ReturnType)


### PR DESCRIPTION
Fixes #34 

This PR adds version support to the `internalHandler.handleSingleRuleset` method, and appropriate testing around it.  This will allow us to request specific versions of the rule-set from the UI. 