### PR TITLE
Add ability to configure etcd store default limit

### DIFF
--- a/cmd/regula/cli/cli.go
+++ b/cmd/regula/cli/cli.go
@@ -22,8 +22,9 @@ import (
 // Config holds the server configuration.
 type Config struct {
 	Etcd struct {
-		Endpoints []string `config:"etcd-endpoints"`
-		Namespace string   `config:"etcd-namespace"`
+		Endpoints    []string `config:"etcd-endpoints"`
+		DefaultLimit int      `config:"etcd-default-limit"`
+		Namespace    string   `config:"etcd-namespace"`
 	}
 	Server struct {
 		Address      string        `config:"addr"`
@@ -40,6 +41,7 @@ func LoadConfig(args []string) (*Config, error) {
 	var cfg Config
 	flag := stdflag.NewFlagSet("", stdflag.ContinueOnError)
 	flag.StringVar(&cfg.Etcd.Namespace, "etcd-namespace", "", "etcd namespace to use")
+	flag.IntVar(&cfg.Etcd.DefaultLimit, "etcd-default-limit", 50, "etcd default limit for Get requests")
 	flag.StringVar(&cfg.LogLevel, "log-level", zerolog.DebugLevel.String(), "debug level")
 	cfg.Etcd.Endpoints = []string{"127.0.0.1:2379"}
 	flag.Var(commaSeparatedFlag{&cfg.Etcd.Endpoints}, "etcd-endpoints", "comma separated etcd endpoints")

--- a/cmd/regula/main.go
+++ b/cmd/regula/main.go
@@ -34,9 +34,10 @@ func main() {
 	defer etcdCli.Close()
 
 	service := etcd.RulesetService{
-		Client:    etcdCli,
-		Namespace: cfg.Etcd.Namespace,
-		Logger:    logger.With().Str("service", "etcd").Logger(),
+		Client:       etcdCli,
+		DefaultLimit: cfg.Etcd.DefaultLimit,
+		Namespace:    cfg.Etcd.Namespace,
+		Logger:       logger.With().Str("service", "etcd").Logger(),
 	}
 
 	srv := server.New(&service, server.Config{

--- a/store/etcd/rulesets.go
+++ b/store/etcd/rulesets.go
@@ -21,11 +21,14 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
+const maxLimit = 100
+
 // RulesetService manages the rulesets using etcd.
 type RulesetService struct {
-	Client    *clientv3.Client
-	Logger    zerolog.Logger
-	Namespace string
+	Client       *clientv3.Client
+	DefaultLimit int
+	Logger       zerolog.Logger
+	Namespace    string
 }
 
 // List returns all the rulesets entries under the given prefix.
@@ -34,8 +37,8 @@ func (s *RulesetService) List(ctx context.Context, prefix string, limit int, con
 
 	var key string
 
-	if limit < 0 || limit > 100 {
-		limit = 50 // TODO(asdine): make this configurable in future releases.
+	if limit < 0 || limit > maxLimit {
+		limit = s.DefaultLimit
 	}
 
 	if continueToken != "" {


### PR DESCRIPTION
Resolve #121 

This PR introduce a new option `etc-default-limit` for `cmd/regula`. By default the limit is 50.